### PR TITLE
Chore [#4] adjust extension 추가

### DIFF
--- a/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
+++ b/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C3A4615B2A4FD44800734EF8 /* adjust+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A4615A2A4FD44800734EF8 /* adjust+.swift */; };
 		C3A799972A49490A00D3EFD8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A799962A49490A00D3EFD8 /* AppDelegate.swift */; };
 		C3A799992A49490A00D3EFD8 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A799982A49490A00D3EFD8 /* SceneDelegate.swift */; };
 		C3A7999B2A49490A00D3EFD8 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A7999A2A49490A00D3EFD8 /* ViewController.swift */; };
@@ -48,6 +49,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		C3A4615A2A4FD44800734EF8 /* adjust+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "adjust+.swift"; sourceTree = "<group>"; };
 		C3A799932A49490A00D3EFD8 /* YELLO-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "YELLO-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C3A799962A49490A00D3EFD8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C3A799982A49490A00D3EFD8 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -163,6 +165,7 @@
 				C3A799E02A494D6800D3EFD8 /* UIStackView+.swift */,
 				C3A799DD2A494D6800D3EFD8 /* UITextField+.swift */,
 				C3A799DE2A494D6800D3EFD8 /* UIView+.swift */,
+				C3A4615A2A4FD44800734EF8 /* adjust+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -373,6 +376,7 @@
 				C3A799D22A494CFF00D3EFD8 /* NetworkResult.swift in Sources */,
 				C3A799E92A494D6800D3EFD8 /* UITextField+.swift in Sources */,
 				C3A799D42A494D0C00D3EFD8 /* a.swift in Sources */,
+				C3A4615B2A4FD44800734EF8 /* adjust+.swift in Sources */,
 				C3A799C42A494B1500D3EFD8 /* Color.swift in Sources */,
 				C3A799C22A494B0F00D3EFD8 /* Font.swift in Sources */,
 				C3A799C02A494B0200D3EFD8 /* String.swift in Sources */,

--- a/YELLO-iOS/YELLO-iOS/Global/Extensions/adjust+.swift
+++ b/YELLO-iOS/YELLO-iOS/Global/Extensions/adjust+.swift
@@ -1,0 +1,62 @@
+//
+//  adjust+.swift
+//  YELLO-iOS
+//
+//  Created by 정채은 on 2023/07/01.
+//
+
+import UIKit
+
+extension CGFloat {
+    var adjusted: CGFloat {
+        let ratio: CGFloat = UIScreen.main.bounds.width / 375
+        let ratioH: CGFloat = UIScreen.main.bounds.height / 667
+        return ratio <= ratioH ? self * ratio : self * ratioH
+    }
+    
+    var adjustedWidth: CGFloat {
+        let ratio: CGFloat = UIScreen.main.bounds.width / 375
+        return CGFloat(self) * ratio
+    }
+    
+    var adjustedHeight: CGFloat {
+        let ratio: CGFloat = UIScreen.main.bounds.height / 667
+        return CGFloat(self) * ratio
+    }
+}
+
+extension Int {
+    var adjusted: CGFloat {
+        let ratio: CGFloat = UIScreen.main.bounds.width / 375
+        let ratioH: CGFloat = UIScreen.main.bounds.height / 667
+        return ratio <= ratioH ? CGFloat(self) * ratio : CGFloat(self) * ratioH
+    }
+    
+    var adjustedWidth: CGFloat {
+        let ratio: CGFloat = UIScreen.main.bounds.width / 375
+        return CGFloat(self) * ratio
+    }
+    
+    var adjustedHeight: CGFloat {
+        let ratio: CGFloat = UIScreen.main.bounds.height / 667
+        return CGFloat(self) * ratio
+    }
+}
+
+extension Double {
+    var adjusted: CGFloat {
+        let ratio: CGFloat = UIScreen.main.bounds.width / 375
+        let ratioH: CGFloat = UIScreen.main.bounds.height / 667
+        return ratio <= ratioH ? CGFloat(self) * ratio : CGFloat(self) * ratioH
+    }
+    
+    var adjustedWidth: CGFloat {
+        let ratio: CGFloat = UIScreen.main.bounds.width / 375
+        return CGFloat(self) * ratio
+    }
+    
+    var adjustedHeight: CGFloat {
+        let ratio: CGFloat = UIScreen.main.bounds.height / 667
+        return CGFloat(self) * ratio
+    }
+}


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- adjust extension 추가했습니다!

```swift
import UIKit

extension CGFloat {
    var adjusted: CGFloat {
        let ratio: CGFloat = UIScreen.main.bounds.width / 375
        let ratioH: CGFloat = UIScreen.main.bounds.height / 667
        return ratio <= ratioH ? self * ratio : self * ratioH
    }
    
    var adjustedWidth: CGFloat {
        let ratio: CGFloat = UIScreen.main.bounds.width / 375
        return CGFloat(self) * ratio
    }
    
    var adjustedHeight: CGFloat {
        let ratio: CGFloat = UIScreen.main.bounds.height / 667
        return CGFloat(self) * ratio
    }
}

extension Int {
    var adjusted: CGFloat {
        let ratio: CGFloat = UIScreen.main.bounds.width / 375
        let ratioH: CGFloat = UIScreen.main.bounds.height / 667
        return ratio <= ratioH ? CGFloat(self) * ratio : CGFloat(self) * ratioH
    }
    
    var adjustedWidth: CGFloat {
        let ratio: CGFloat = UIScreen.main.bounds.width / 375
        return CGFloat(self) * ratio
    }
    
    var adjustedHeight: CGFloat {
        let ratio: CGFloat = UIScreen.main.bounds.height / 667
        return CGFloat(self) * ratio
    }
}

extension Double {
    var adjusted: CGFloat {
        let ratio: CGFloat = UIScreen.main.bounds.width / 375
        let ratioH: CGFloat = UIScreen.main.bounds.height / 667
        return ratio <= ratioH ? CGFloat(self) * ratio : CGFloat(self) * ratioH
    }
    
    var adjustedWidth: CGFloat {
        let ratio: CGFloat = UIScreen.main.bounds.width / 375
        return CGFloat(self) * ratio
    }
    
    var adjustedHeight: CGFloat {
        let ratio: CGFloat = UIScreen.main.bounds.height / 667
        return CGFloat(self) * ratio
    }
}

```



## 📌 PR Point!
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 사용방법 : float, int, double 뒤에 `.adjust` 붙여주시면 됩니다.
- se2로 작업하시고 모든 레이아웃 숫자 뒤에 `.adjust` 붙여주시면 비율에 맞춰서 모든 기기 대응 가능합니다. 
예를 들어
```swift
import UIKit

import SnapKit
import Then

final class MainViewController: UIViewController {
    
    private let firstView = UIView().then {
        $0.backgroundColor = .blue
    }
    
    private let secondView = UIView().then {
        $0.backgroundColor = .red
    }

    override func viewDidLoad() {
        super.viewDidLoad()
        
        setUI()
        setLayout()
    }
}

extension MainViewController {
    private func setUI() {
        view.backgroundColor = .white
    }
    
    private func setLayout() {
        view.addSubview(firstView)
        view.addSubview(secondView)
        
        firstView.snp.makeConstraints{
            $0.top.equalToSuperview().offset(100.adjusted)
            $0.width.height.equalTo(100.adjusted)
            $0.leading.equalToSuperview().offset(100.adjusted)
        }
        
        secondView.snp.makeConstraints{
            $0.top.equalTo(firstView.snp.bottom).offset(100)
            $0.width.height.equalTo(100)
            $0.leading.equalToSuperview().offset(100)
        }
    }
}
```
이렇게 구현하였을시에

|    iPhone SE2  ,  iPhone 14 Pro   |
| :-------------: |
| <img width="738" alt="스크린샷 2023-07-01 오후 12 33 51" src="https://github.com/team-yello/YELLO-iOS/assets/109775321/86543135-2f1f-4c2b-ad87-aba02a5010da"> |

파란 뷰는 adjust를 사용, 빨간 뷰는 adjust를 사용하지 않았습니다. 
se2 비율에 맞춰서 모든 기기에 비율이 적용되기 때문에 이 부분 꼭 고려하시고 작업해주세요!

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #4
