### PR TITLE
Fix [#52] keyboard 이용 return

### DIFF
--- a/YELLO-iOS/YELLO-iOS/Global/Extensions/UILabel+.swift
+++ b/YELLO-iOS/YELLO-iOS/Global/Extensions/UILabel+.swift
@@ -36,6 +36,19 @@ extension UILabel {
         attributedText = attributedString
     }
     
+    func asColors(targetStrings: [String], color: UIColor?) {
+            guard let attributedText = attributedText else { return }
+            
+            let mutableAttributedString = NSMutableAttributedString(attributedString: attributedText)
+            
+            for targetString in targetStrings {
+                let range = (mutableAttributedString.string as NSString).range(of: targetString)
+                mutableAttributedString.addAttribute(.foregroundColor, value: color ?? textColor, range: range)
+            }
+            
+            self.attributedText = mutableAttributedString
+        }
+    
     /// 텍스트가 두 줄일 때 각 줄에 폰트, 색상을 다르게 주는 함수
     static func createTwoLineLabel(text: String, firstLineFont: UIFont, firstLineColor: UIColor, secondLineFont: UIFont, secondLineColor: UIColor) -> UILabel {
         let label = UILabel()

--- a/YELLO-iOS/YELLO-iOS/Global/Extensions/UILabel+.swift
+++ b/YELLO-iOS/YELLO-iOS/Global/Extensions/UILabel+.swift
@@ -37,17 +37,17 @@ extension UILabel {
     }
     
     func asColors(targetStrings: [String], color: UIColor?) {
-            guard let attributedText = attributedText else { return }
-            
-            let mutableAttributedString = NSMutableAttributedString(attributedString: attributedText)
-            
-            for targetString in targetStrings {
-                let range = (mutableAttributedString.string as NSString).range(of: targetString)
-                mutableAttributedString.addAttribute(.foregroundColor, value: color ?? textColor, range: range)
-            }
-            
-            self.attributedText = mutableAttributedString
+        guard let attributedText = attributedText else { return }
+        
+        let mutableAttributedString = NSMutableAttributedString(attributedString: attributedText)
+        
+        for targetString in targetStrings {
+            let range = (mutableAttributedString.string as NSString).range(of: targetString)
+            mutableAttributedString.addAttribute(.foregroundColor, value: color ?? textColor, range: range)
         }
+        
+        self.attributedText = mutableAttributedString
+    }
     
     /// 텍스트가 두 줄일 때 각 줄에 폰트, 색상을 다르게 주는 함수
     static func createTwoLineLabel(text: String, firstLineFont: UIFont, firstLineColor: UIColor, secondLineFont: UIFont, secondLineColor: UIColor) -> UILabel {
@@ -56,7 +56,7 @@ extension UILabel {
         
         let lines = text.components(separatedBy: "\n")
         let firstLineLength = lines.first?.count ?? 3
-
+        
         // 첫 번째 줄 속성 적용
         attributedText.addAttribute(.font, value: firstLineFont, range: NSRange(location: 0, length: firstLineLength))
         attributedText.addAttribute(.foregroundColor, value: firstLineColor, range: NSRange(location: 0, length: firstLineLength))
@@ -75,7 +75,7 @@ extension UILabel {
         
         return label
     }
-
+    
     /// 텍스트가 두 줄일 때 첫째줄의 색상만 바꾸는 함수
     func updateLabelAppearance() {
         let lines = self.text?.components(separatedBy: "\n")
@@ -86,5 +86,5 @@ extension UILabel {
         attributedString.addAttributes([.foregroundColor: UIColor.grayscales600, .font: UIFont.uiLabelSmall], range: NSRange(location: firstLineLength, length: attributedString.length - firstLineLength))
         self.attributedText = attributedString
     }
- 
+    
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/Base/SearchBaseViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/Base/SearchBaseViewController.swift
@@ -90,6 +90,10 @@ extension SearchBaseViewController: UITextFieldDelegate {
         searchView.searchResultTableView.reloadData()
     }
     
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.endEditing(true)
+    }
+    
 }
 
 // MARK: - extension

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/RecommendIdViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/RecommendIdViewController.swift
@@ -69,6 +69,10 @@ extension RecommendIdViewController: UITextFieldDelegate {
         baseView.recommendIdTextField.textField.setButtonState(state: .cancel)
     }
     
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.endEditing(true)
+    }
+    
     func textFieldDidEndEditing(_ textField: UITextField) {
         baseView.recommendIdTextField.textField.setButtonState(state: .id)
         checkButtonEnable()

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/SchoolSearchViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/SchoolSearchViewController.swift
@@ -68,6 +68,10 @@ extension SchoolSearchViewController: UITextFieldDelegate {
         self.present(nextViewController, animated: true)
     }
     
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.endEditing(true)
+    }
+    
 }
 
 // MARK: SearchResultTableViewSelectDelegate

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/StudentInfoViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/StudentInfoViewController.swift
@@ -52,6 +52,18 @@ class StudentInfoViewController: OnboardingBaseViewController {
         
         present(nav, animated: true, completion: nil)
     }
+    
+    func checkButtonEnable() {
+        let majorText = baseView.majorTextField.textField.text ?? ""
+        let studentIDText = baseView.studentIDTextField.textField.text ?? ""
+        
+        let isMajorTextFilled = !majorText.isEmpty
+        let isStudentIDTextFilled = !studentIDText.isEmpty
+        
+        let isButtonEnabled = isMajorTextFilled && isStudentIDTextFilled
+        
+        nextButton.setButtonEnable(state: isButtonEnabled)
+    }
 }
 
 // MARK: - extension
@@ -71,16 +83,8 @@ extension StudentInfoViewController: UITextFieldDelegate {
         }
     }
     
-    func checkButtonEnable() {
-        let majorText = baseView.majorTextField.textField.text ?? ""
-        let studentIDText = baseView.studentIDTextField.textField.text ?? ""
-        
-        let isMajorTextFilled = !majorText.isEmpty
-        let isStudentIDTextFilled = !studentIDText.isEmpty
-        
-        let isButtonEnabled = isMajorTextFilled && isStudentIDTextFilled
-        
-        nextButton.setButtonEnable(state: isButtonEnabled)
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.endEditing(true)
     }
 }
 

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/UserInfoViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/UserInfoViewController.swift
@@ -89,8 +89,7 @@ class UserInfoViewController: OnboardingBaseViewController {
             idTextFieldView.textField.setButtonState(state: .id)
             idTextFieldView.helperLabel.setLabelStyle(text: StringLiterals.Onboarding.idHelper, State: .id)
         }
-        
-        
+                
         if !isIDEmpty, !isNameEmpty, isKoreanOnly, isEnglishOnly {
             nextButton.setButtonEnable(state: true)
             idTextFieldView.textField.setButtonState(state: .done)
@@ -125,6 +124,5 @@ extension UserInfoViewController: UITextFieldDelegate {
     func textFieldDidEndEditing(_ textField: UITextField) {
         self.checkButtonEnable()
     }
-    
     
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/AddFriendsView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/AddFriendsView.swift
@@ -59,7 +59,8 @@ class AddFriendsView: BaseView {
             $0.font = .uiLabelLarge
             $0.textColor = .purpleSub400
             
-            $0.asColors(targetStrings: ["선택된 친구", "명"], color: .white)        }
+            $0.asColors(targetStrings: ["선택된 친구", "명"], color: .white)
+        }
         
         friendsTableView.do {
             $0.register(FriendsTableViewCell.self, forCellReuseIdentifier: FriendsTableViewCell.identifier)
@@ -119,5 +120,6 @@ extension AddFriendsView: FriendsTableViewCellDelegate {
         kakaoFriendTableViewModel[indexPath.row].isButtonSelected = isSelected
         count = kakaoFriendTableViewModel.filter { !$0.isButtonSelected }.count
         countFriendLabel.text = "선택된 친구 \(count)명"
+        countFriendLabel.asColors(targetStrings: ["선택된 친구", "명"], color: .white)
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/AddFriendsView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/AddFriendsView.swift
@@ -57,8 +57,9 @@ class AddFriendsView: BaseView {
         countFriendLabel.do {
             $0.text = "선택된 친구 \(count)명"
             $0.font = .uiLabelLarge
-            $0.textColor = .white
-        }
+            $0.textColor = .purpleSub400
+            
+            $0.asColors(targetStrings: ["선택된 친구", "명"], color: .white)        }
         
         friendsTableView.do {
             $0.register(FriendsTableViewCell.self, forCellReuseIdentifier: FriendsTableViewCell.identifier)

--- a/YELLO-iOS/YELLO-iOS/Presentation/Recommending/View/EmptyFriendView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Recommending/View/EmptyFriendView.swift
@@ -106,10 +106,7 @@ extension EmptyFriendView {
     @objc func showAlert() {
         guard let viewController = UIApplication.shared.keyWindow?.rootViewController else { return }
         
-        
         invitingView.removeFromSuperview()
-        
-        
         invitingView = InvitingView()
         invitingView.frame = viewController.view.bounds
         invitingView.autoresizingMask = [.flexibleWidth, .flexibleHeight]


### PR DESCRIPTION
## ⛏ 작업 내용
- `return` 키를 이용해서 입력을 완료할 수 있도록 코드를 추가했습니다. 
- 친구 추가뷰에서 선택된 친구 라벨 색상을 변경했습니다. 


## 📌 PR Point!
- `return` 키 이용 입력 완료 
https://github.com/team-yello/YELLO-iOS/blob/98aed88bd1c5b2b88dda8e3953a47f45e57606ae/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/StudentInfoViewController.swift#L86-L88
- 여러 개의 텍스트를 한 번에 색상을 변경할 수 있도록 extension 추가
https://github.com/team-yello/YELLO-iOS/blob/98aed88bd1c5b2b88dda8e3953a47f45e57606ae/YELLO-iOS/YELLO-iOS/Global/Extensions/UILabel%2B.swift#L39-L50


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
|친구 선택 뷰 | ![Simulator Screen Recording - iPhone SE (3rd generation) - 2023-07-15 at 14 54 39](https://github.com/team-yello/YELLO-iOS/assets/68178395/bb304014-558f-4c9d-bbcf-7ce9f1cf238e) |
|키보드 return | ![Simulator Screen Recording - iPhone SE (3rd generation) - 2023-07-15 at 14 56 15](https://github.com/team-yello/YELLO-iOS/assets/68178395/aa26d9b8-aa69-4758-a9f4-1c8d39ff2fab) |


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #52 
