### PR TITLE
Network [#87] 계정 탈퇴 API 연결, 로그아웃 구현

### DIFF
--- a/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
+++ b/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
@@ -1774,13 +1774,13 @@
 		C3A799A82A49490D00D3EFD8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3662A0E22A63474000F482EF /* Config.xcconfig */;
-      buildSettings = {
+			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 349HWJV2J8;
+				DEVELOPMENT_TEAM = Q827V73L8U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "YELLO-iOS/Info.plist";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -1795,7 +1795,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "YELLO-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = "chaen.YELLO-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1813,7 +1813,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 349HWJV2J8;
+				DEVELOPMENT_TEAM = Q827V73L8U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "YELLO-iOS/Info.plist";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -1828,7 +1828,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "YELLO-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = "chaen.YELLO-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/YELLO-iOS/YELLO-iOS/Global/KeychainHandler.swift
+++ b/YELLO-iOS/YELLO-iOS/Global/KeychainHandler.swift
@@ -23,7 +23,8 @@ struct KeychainHandler {
     
     var accessToken: String {
         get {
-            return KeychainWrapper.standard.string(forKey: accessTokenKey) ?? ""
+            
+            return "Bearer \(KeychainWrapper.standard.string(forKey: accessTokenKey) ?? "")"
         }
         set {
             KeychainWrapper.standard.set(newValue, forKey: accessTokenKey)

--- a/YELLO-iOS/YELLO-iOS/Global/KeychainHandler.swift
+++ b/YELLO-iOS/YELLO-iOS/Global/KeychainHandler.swift
@@ -137,7 +137,7 @@ func deleteUsername() {
 func isFirstTime() -> Bool {
     let defaults = UserDefaults.standard
     if defaults.object(forKey: "isFirstTime") == nil {
-        defaults.set("No", forKey:"isFirstTime")
+        defaults.set("No", forKey: "isFirstTime")
         return true
     } else {
         return false

--- a/YELLO-iOS/YELLO-iOS/Network/Base/HTTPHeaderFieldKey.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Base/HTTPHeaderFieldKey.swift
@@ -17,7 +17,7 @@ enum HTTPHeaderFieldKey: String {
 
 enum HTTPHeaderFieldValue: String {
     case json = "Application/json"
-    case accessToken = "Bearer eyJ0eXBlIjoiYWNjZXNzVG9rZW4iLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyOTExNzI0MDAyIiwianRpIjoiMTQ4IiwiaWF0IjoxNjg5NjE5NzkzLCJleHAiOjE2ODk3MDYxOTN9.pBvnzLuwAg2wDZZ77HUBbdZvE0-Xvp6XRhqF9ZDA1xc"
+    case accessToken
 }
 
 enum HTTPHeaderType {

--- a/YELLO-iOS/YELLO-iOS/Network/Base/TargetType.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Base/TargetType.swift
@@ -30,7 +30,7 @@ extension TargetType {
         case .hasAccessToken:
             return [
                 HTTPHeaderFieldKey.contentType.rawValue: HTTPHeaderFieldValue.json.rawValue,
-                HTTPHeaderFieldKey.accessToken.rawValue: HTTPHeaderFieldValue.accessToken.rawValue
+                HTTPHeaderFieldKey.accessToken.rawValue: KeychainHandler.shared.accessToken
             ]
         }
     }
@@ -48,7 +48,7 @@ extension TargetType {
             urlRequest.setValue(HTTPHeaderFieldValue.json.rawValue, forHTTPHeaderField: HTTPHeaderFieldKey.contentType.rawValue)
         case .hasAccessToken:
             urlRequest.setValue(HTTPHeaderFieldValue.json.rawValue, forHTTPHeaderField: HTTPHeaderFieldKey.contentType.rawValue)
-            urlRequest.setValue(HTTPHeaderFieldValue.accessToken.rawValue, forHTTPHeaderField: HTTPHeaderFieldKey.authentication.rawValue)
+            urlRequest.setValue(KeychainHandler.shared.accessToken, forHTTPHeaderField: HTTPHeaderFieldKey.authentication.rawValue)
         }
 
         switch parameters {

--- a/YELLO-iOS/YELLO-iOS/Network/Onboarding/Router/OnboardingTarget.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Onboarding/Router/OnboardingTarget.swift
@@ -21,17 +21,17 @@ enum OnboardingTarget {
 extension OnboardingTarget: TargetType {
     var headerType: HTTPHeaderType {
         switch self {
-        case .postTokenChange(let _):
+        case .postTokenChange:
             return .hasAccessToken
-        case .getSchoolList(let _):
+        case .getSchoolList:
             return .plain
-        case .getMajorList(let _):
+        case .getMajorList:
             return .plain
-        case .getCheckDuplicate(let _):
+        case .getCheckDuplicate:
             return .hasAccessToken
-        case .postFirendsList(let _):
+        case .postFirendsList:
             return .plain
-        case .postUserInfo(let _):
+        case .postUserInfo:
             return .hasAccessToken
         }
     }
@@ -42,7 +42,7 @@ extension OnboardingTarget: TargetType {
             return .post
         case .getSchoolList:
             return .get
-        case .getMajorList(_):
+        case .getMajorList:
             return .get
         case .getCheckDuplicate:
             return .get
@@ -55,17 +55,17 @@ extension OnboardingTarget: TargetType {
     
     var path: String {
         switch self {
-        case .postTokenChange(_):
+        case .postTokenChange:
             return "/auth/oauth"
-        case .getSchoolList(let dto):
+        case .getSchoolList:
             return "/auth/school/school"
-        case .getCheckDuplicate(let id):
+        case .getCheckDuplicate:
             return "/auth/valid"
-        case .postUserInfo(_):
+        case .postUserInfo:
             return "/auth/signup"
-        case .getMajorList(_):
+        case .getMajorList:
             return "/auth/school/department"
-        case .postFirendsList(_):
+        case .postFirendsList:
             return "/auth/friend"
         }
     }
@@ -82,7 +82,7 @@ extension OnboardingTarget: TargetType {
             return .requestWithBody(dto)
         case .getMajorList(let dto):
             return .requestQuery(dto)
-        case .postFirendsList(let query,let dto):
+        case .postFirendsList(let query, let dto):
             return .requestQueryWithBody(query, bodyParameter: dto)
         }
     }

--- a/YELLO-iOS/YELLO-iOS/Network/Onboarding/Router/OnboardingTarget.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Onboarding/Router/OnboardingTarget.swift
@@ -31,7 +31,7 @@ extension OnboardingTarget: TargetType {
             return .hasAccessToken
         case .postFirendsList(let _):
             return .plain
-        case .postUserInfo(let _, let _2):
+        case .postUserInfo(let _):
             return .hasAccessToken
         }
     }

--- a/YELLO-iOS/YELLO-iOS/Network/Profile/DTO/Request/DeleteUserRequestDTO.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Profile/DTO/Request/DeleteUserRequestDTO.swift
@@ -1,0 +1,8 @@
+//
+//  DeleteUserRequestDTO.swift
+//  YELLO-iOS
+//
+//  Created by 지희의 MAC on 2023/07/19.
+//
+
+import Foundation

--- a/YELLO-iOS/YELLO-iOS/Network/Profile/Router/ProfileTarget.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Profile/Router/ProfileTarget.swift
@@ -13,6 +13,7 @@ enum ProfileTarget {
     case profileUser(userId: Int)
     case profileFriend(_ queryDTO: ProfileFriendRequestQueryDTO)
     case profileDeleteFriend(id: Int)
+    case deleteUser
 }
 
 extension ProfileTarget: TargetType {
@@ -23,6 +24,8 @@ extension ProfileTarget: TargetType {
         case .profileFriend(let _):
             return .hasAccessToken
         case .profileDeleteFriend(let id):
+            return .hasAccessToken
+        case .deleteUser:
             return .hasAccessToken
         }
     }
@@ -35,6 +38,8 @@ extension ProfileTarget: TargetType {
             return .get
         case .profileDeleteFriend:
             return .delete
+        case .deleteUser:
+            return .delete
         }
     }
     
@@ -46,6 +51,8 @@ extension ProfileTarget: TargetType {
             return "/friend"
         case .profileDeleteFriend(let id):
             return "/friend/\(id)"
+        case .deleteUser:
+            return "/user"
         }
     }
 
@@ -56,6 +63,8 @@ extension ProfileTarget: TargetType {
         case let .profileFriend(queryDTO):
             return .requestQuery(queryDTO)
         case .profileDeleteFriend:
+            return .requestPlain
+        case .deleteUser:
             return .requestPlain
         }
     }

--- a/YELLO-iOS/YELLO-iOS/Network/Profile/Service/ProfileService.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Profile/Service/ProfileService.swift
@@ -13,6 +13,8 @@ protocol ProfileServiceProtocol {
     func profileFriend(queryDTO: ProfileFriendRequestQueryDTO, completion: @escaping (NetworkResult<BaseResponse<ProfileFriendResponseDTO>>) -> Void)
     
     func profileDeleteFriend(id: Int, completion: @escaping (NetworkResult<BaseResponse<Bool>>) -> Void)
+    
+    func userDelete(completion: @escaping (NetworkResult<BaseResponse<Bool>>) -> Void)
 }
 
 final class ProfileService: APIRequestLoader<ProfileTarget>, ProfileServiceProtocol {
@@ -29,5 +31,9 @@ final class ProfileService: APIRequestLoader<ProfileTarget>, ProfileServiceProto
     func profileDeleteFriend(id: Int, completion: @escaping (NetworkResult<BaseResponse<Bool>>) -> Void) {
         fetchData(target: .profileDeleteFriend(id: id),
                   responseData: BaseResponse<Bool>.self, completion: completion)
+    }
+    
+    func userDelete(completion: @escaping (NetworkResult<BaseResponse<Bool>>) -> Void) {
+        fetchData(target: .deleteUser, responseData: BaseResponse<Bool>.self, completion: completion)
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/MyYelloDetailModel.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/MyYelloDetailModel.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 
-
 // MARK: - MyYelloDetailModel
 struct MyYelloDetailModel: Codable {
     let status: Int
@@ -32,7 +31,6 @@ var MyYelloDetailModelDummy: [MyYelloDetailModelData] = [
     MyYelloDetailModelData(nameHint: -1, colorIndex: 6, isAnswerRevealed: false, senderName: "강국희", vote: Vote(nameHead: "술자리에서", nameFoot: "가", keywordHead: "사라진다면", keyword: "달빛산책간 거", keywordFoot: "(이)야")),
     MyYelloDetailModelData(nameHint: -1, colorIndex: 1, isAnswerRevealed: false, senderName: "권세훈", vote: Vote(nameHead: "술자리에서", nameFoot: "가", keywordHead: "사라진다면", keyword: "달빛산책간 거", keywordFoot: "(이)야"))
 ]
-
 
 struct MyYelloBackgroundColorDummy {
     let backgroundColorTop: UIColor

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoConnectViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoConnectViewController.swift
@@ -31,8 +31,7 @@ class KakaoConnectViewController: BaseViewController {
         TalkApi.shared.profile {(profile, error) in
             if let error = error {
                 print(error)
-            }
-            else {
+            } else {
                 _ = profile
                 self.navigationController?.pushViewController(SchoolSearchViewController(), animated: true)
             }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoLoginViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoLoginViewController.swift
@@ -65,7 +65,7 @@ class KakaoLoginViewController: BaseViewController {
                     print("카카오 계정으로 로그인 성공")
                     
                     guard let kakaoToken = oauthToken?.accessToken else { return }
-                    let queryDTO = KakaoLoginRequestDTO(accessToken: kakaoToken, social: "Kakao")
+                    let queryDTO = KakaoLoginRequestDTO(accessToken: kakaoToken, social: "KAKAO")
                     
                     NetworkService.shared.onboardingService.postTokenChange(queryDTO: queryDTO) { result in
                         switch result {
@@ -92,8 +92,10 @@ class KakaoLoginViewController: BaseViewController {
                                 }
                                 self.navigationController?.pushViewController(KakaoConnectViewController(), animated: true)
                             } else if data.status == 201 {
+                                guard let data = data.data else { return }
+                                KeychainHandler.shared.accessToken = data.accessToken
+                                UserDefaults.standard.set(true, forKey: "isLoggedIn")
                                 self.navigationController?.pushViewController(YELLOTabBarController(), animated: true)
-                                print(data.data)
                             }
                         default:
                             print("network failure")

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/UserInfoViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/UserInfoViewController.swift
@@ -104,7 +104,7 @@ class UserInfoViewController: OnboardingBaseViewController {
         if !isIDEmpty, !isNameEmpty, isKoreanOnly, isEnglishOnly, !isIdDuplicate {
             nextButton.setButtonEnable(state: true)
             idTextFieldView.textField.setButtonState(state: .done)
-            idTextFieldView.helperLabel.setLabelStyle(text: StringLiterals.Onboarding.nameHelper, State: .done)
+            idTextFieldView.helperLabel.setLabelStyle(text: "", State: .done)
             nameTextFieldView.textField.setButtonState(state: .done)
         } else {
             nextButton.setButtonEnable(state: false)

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/View/ProfileSettingView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/View/ProfileSettingView.swift
@@ -52,7 +52,6 @@ final class ProfileSettingView: BaseView {
         
         logoutButton.do {
             $0.updateTitle(text: StringLiterals.Profile.Setting.logout)
-            $0.addTarget(self, action: #selector(logoutButtonTapped), for: .touchUpInside)
         }
         
         versionLabel.do {
@@ -133,24 +132,22 @@ final class ProfileSettingView: BaseView {
     }
     
     @objc private func centerButtonTapped() {
-        //고객센터 링크 연결
+        // 고객센터 링크 연결
         let url = URL(string: "https://www.google.com/")!
         UIApplication.shared.open(url, options: [:], completionHandler: nil)
     }
     
     @objc private func privacyButtonTapped() {
-        //개인정보 처리방침 링크 연결
+        // 개인정보 처리방침 링크 연결
         let url = URL(string: "https://www.google.com/")!
         UIApplication.shared.open(url, options: [:], completionHandler: nil)
     }
         
     @objc private func serviveButtonTapped() {
-        //이용약관 링크 연결
+        // 이용약관 링크 연결
         let url = URL(string: "https://www.google.com/")!
         UIApplication.shared.open(url, options: [:], completionHandler: nil)
     }
         
-    @objc private func logoutButtonTapped() {
-        //로그아웃 로직 구현
-    }
+    
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/ViewController/ProfileSettingViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/ViewController/ProfileSettingViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import SnapKit
 import Then
+import KakaoSDKUser
 
 final class ProfileSettingViewController: BaseViewController {
     
@@ -25,6 +26,7 @@ final class ProfileSettingViewController: BaseViewController {
         view.backgroundColor = .black
         profileSettingView.settingNavigationBarView.handleBackButtonDelegate = self
         profileSettingView.handleWithdrawalButtonDelegate = self
+        profileSettingView.logoutButton.addTarget(self, action: #selector(logoutButtonTapped), for: .touchUpInside)
     }
     
     override func setLayout() {
@@ -49,5 +51,23 @@ extension ProfileSettingViewController: HandleWithdrawalButtonDelegate {
     func withdrawalButtonTapped() {
         let withdrawalCheckViewController = WithdrawalCheckViewController()
         navigationController?.pushViewController(withdrawalCheckViewController, animated: true)
+    }
+    
+    @objc private func logoutButtonTapped() {
+        // 로그아웃 로직 구현
+        UserApi.shared.logout {(error) in
+            if let error = error {
+                print(error)
+            } else {
+                print("logout() success.")
+                let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as! SceneDelegate
+                
+               UserDefaults.standard.set(false, forKey: "isLoggedIn")
+               sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: KakaoLoginViewController())
+                
+                self.navigationController?.popToRootViewController(animated: true)
+            }
+            
+        }
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalAlertView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalAlertView.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import SnapKit
 import Then
+import KakaoSDKUser
 
 final class WithdrawalAlertView: BaseView {
     
@@ -93,10 +94,28 @@ extension WithdrawalAlertView {
     }
     
     @objc func yesButtonClicked() {
-//        탈퇴 로직 구현
-        print("탈퇴")
-        let splashViewController = SchoolSearchViewController()
-        let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
-        sceneDelegate?.window?.rootViewController = UINavigationController(rootViewController: splashViewController)
+        NetworkService.shared.profileService.userDelete { result in
+            switch result{
+            case .success(let data):
+                if data.status == 200{
+                    UserApi.shared.unlink {(error) in
+                        if let error = error {
+                            print(error)
+                        }
+                        else {
+                            print("unlink() success.")
+                        }
+                    }
+                    let splashViewController = KakaoLoginViewController()
+                    let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
+                    
+                    sceneDelegate?.window?.rootViewController = UINavigationController(rootViewController: splashViewController)
+                }
+            default:
+                print("NetWorkFaliure")
+                return
+            }
+        }
+        
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalAlertView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalAlertView.swift
@@ -95,20 +95,20 @@ extension WithdrawalAlertView {
     
     @objc func yesButtonClicked() {
         NetworkService.shared.profileService.userDelete { result in
-            switch result{
+            switch result {
             case .success(let data):
-                if data.status == 200{
+                if data.status == 200 {
                     UserApi.shared.unlink {(error) in
                         if let error = error {
                             print(error)
-                        }
-                        else {
+                        } else {
                             print("unlink() success.")
                         }
                     }
+                    
+                    KeychainHandler.shared.removeAll()
                     let splashViewController = KakaoLoginViewController()
                     let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
-                    
                     sceneDelegate?.window?.rootViewController = UINavigationController(rootViewController: splashViewController)
                 }
             default:


### PR DESCRIPTION
## ⛏ 작업 내용
- 계정 탈퇴 API를 연결했습니다. 
- 로그아웃 구현했습니다. 

## 📌 PR Point!
- 계정 탈퇴 API 연결 후 다음과 같은 로직을 추가했습니다. 
> 카카오 로그인 연결 끊기
https://github.com/team-yello/YELLO-iOS/blob/23aac6056d5e6345bc01ccfd87204dc5c049b2eb/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalAlertView.swift#L99-L108
> `keyChain` 안의 정보 삭제
https://github.com/team-yello/YELLO-iOS/blob/23aac6056d5e6345bc01ccfd87204dc5c049b2eb/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalAlertView.swift#L109
> 회원 탈퇴 이후 `rootView` 변경
https://github.com/team-yello/YELLO-iOS/blob/23aac6056d5e6345bc01ccfd87204dc5c049b2eb/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalAlertView.swift#L110-L112

- 로그아웃 시 카카오 계정 로그아웃을 진행합니다. 
https://github.com/team-yello/YELLO-iOS/blob/96504b3d481edc759429029b4bf67065363a71e1/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/ViewController/ProfileSettingViewController.swift#L56-L69


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 로그아웃 | ![Simulator Screen Recording - iPhone 13 - 2023-07-19 at 17 00 57](https://github.com/team-yello/YELLO-iOS/assets/68178395/65fe0b92-4c37-4df4-a7a2-b3e0eb29881f)
d80) |
| 회원 탈퇴  | ![Simulator Screen Recording - iPhone 13 - 2023-07-19 at 17 01 18](https://github.com/team-yello/YELLO-iOS/assets/68178395/89a2840f-c4d0-42a7-835d-b3816f797460) |



### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #87
