### PR TITLE
Feat [#91] 친구 추가 API 연결 및 친구추가 로직 구현 

### DIFF
--- a/YELLO-iOS/YELLO-iOS/Network/Onboarding/DTO/Request/SignUpRequestDTO.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Onboarding/DTO/Request/SignUpRequestDTO.swift
@@ -13,7 +13,7 @@ struct SignUpRequestDTO: Codable {
     let groupID, groupAdmissionYear: Int
     let name, yelloID, gender: String
     let friends: [Int]
-  //  let recommendID: String
+    let recommendID: String?
 
     enum CodingKeys: String, CodingKey {
         case social, uuid, email, profileImage
@@ -21,6 +21,6 @@ struct SignUpRequestDTO: Codable {
         case groupAdmissionYear, name
         case yelloID = "yelloId"
         case gender, friends
-        //case recommendID = "recommendId"
+        case recommendID = "recommendId"
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Network/Profile/DTO/Request/DeleteUserRequestDTO.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Profile/DTO/Request/DeleteUserRequestDTO.swift
@@ -1,8 +1,0 @@
-//
-//  DeleteUserRequestDTO.swift
-//  YELLO-iOS
-//
-//  Created by 지희의 MAC on 2023/07/19.
-//
-
-import Foundation

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Cells/FriendsTableViewCell.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Cells/FriendsTableViewCell.swift
@@ -55,7 +55,6 @@ class FriendsTableViewCell: UITableViewCell {
         nameLabel.text = nil
         schoolLabel.text = nil
         isTapped = false
-        selectedOverlayView.isHidden = true
     }
     
     // MARK: Custom Function
@@ -72,18 +71,6 @@ class FriendsTableViewCell: UITableViewCell {
     private func updateCheckButtonImage() {
         let imageName = isTapped ? ImageLiterals.OnBoarding.icCheckCircleEnable : ImageLiterals.OnBoarding.icCheckCircleYello
         checkButton.setImage(imageName, for: .normal)
-    }
-    
-    /// indexPath 받기
-    private func getIndexPath() -> IndexPath? {
-        guard let tableView = superview as? UITableView else { return nil }
-        return tableView.indexPath(for: self)
-    }
-    
-    // MARK: Objc Function
-    @objc func checkButtonDidTap() {
-        isTapped.toggle()
-        updateCheckButtonImage()
         
         if isTapped {
             if selectedOverlayView.superview == nil {
@@ -98,9 +85,21 @@ class FriendsTableViewCell: UITableViewCell {
         } else {
             selectedOverlayView.removeFromSuperview()
         }
+    }
+    
+    /// indexPath 받기
+    private func getIndexPath() -> IndexPath? {
+        guard let tableView = superview as? UITableView else { return nil }
+        return tableView.indexPath(for: self)
+    }
+    
+    // MARK: Objc Function
+    @objc func checkButtonDidTap() {
+        isTapped.toggle()
         if let indexPath = getIndexPath() {
             delegate?.friendCell(self, didTapButtonAt: indexPath, isSelected: isTapped)
         }
+        updateCheckButtonImage()
     }
 }
 
@@ -116,6 +115,7 @@ extension FriendsTableViewCell {
         
         profileImageView.do {
             $0.backgroundColor = .yelloMain300
+            $0.contentMode = .scaleAspectFill
             $0.makeCornerRound(radius: 21)
         }
         

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/User.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/User.swift
@@ -20,6 +20,7 @@ struct User {
     var yelloId: String = ""
     var gender: String = ""
     var friends: [Int] = []
+    var kakaoFriends: [String] = []
     var recommendId: String = ""
     
     private init() {}

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/AddFriendsViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/AddFriendsViewController.swift
@@ -21,7 +21,7 @@ class AddFriendsViewController: OnboardingBaseViewController {
     var isLoadingData = false
     
     var pageCount = -1
-    var friendsKakaoID: [String] = []
+    var friendsKakaoID: [String] = User.shared.kakaoFriends
     var groupId = User.shared.groupId
     
     var data: JoinedFriendsResponseDTO?
@@ -100,6 +100,12 @@ class AddFriendsViewController: OnboardingBaseViewController {
                 }
             }
         }
+    }
+    
+    override func setUser() {
+        let friends = baseView.joinedFriendsList.filter {$0.isAdded == false}.map { $0.friendInfo.id }
+        print(friends)
+        User.shared.friends = friends
     }
 
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoConnectViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoConnectViewController.swift
@@ -28,11 +28,15 @@ class KakaoConnectViewController: BaseViewController {
     }
     
     @objc func connectButtonDidTap() {
-        TalkApi.shared.profile {(profile, error) in
+        TalkApi.shared.friends {(friends, error) in
             if let error = error {
                 print(error)
             } else {
-                _ = profile
+                var allFriends: [String] = []
+                friends?.elements?.forEach({
+                    allFriends.append($0.uuid)
+                })
+                User.shared.kakaoFriends = allFriends
                 self.navigationController?.pushViewController(SchoolSearchViewController(), animated: true)
             }
         }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoLoginViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoLoginViewController.swift
@@ -31,25 +31,47 @@ class KakaoLoginViewController: BaseViewController {
         if UserApi.isKakaoTalkLoginAvailable() {
             UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
                 if let error = error {
-                    print(error)
+                    print("🚩🚩\(error)")
                 } else {
                     print("----🚩카카오 톡으로 로그인 성공🚩----")
                     
                     guard let kakaoToken = oauthToken?.accessToken else { return }
-                    let queryDTO = KakaoLoginRequestDTO(accessToken: kakaoToken, social: "Kakao")
-                    
+                    let queryDTO = KakaoLoginRequestDTO(accessToken: kakaoToken, social: "KAKAO")
                     NetworkService.shared.onboardingService.postTokenChange(queryDTO: queryDTO) { result in
-                        
                         switch result {
                         case .success(let data):
                             if data.status == 403 {
-                                self.navigationController?.pushViewController(KakaoConnectViewController(), animated: true)
+                                UserApi.shared.me() {(user, error) in
+                                    if let error = error {
+                                        print(error)
+                                    } else {
+                                        print("me() success.")
+                                        _ = user
+                                        guard let user = user else { return }
+                                        guard let uuidInt = user.id else { return }
+                                        let uuid = String(uuidInt)
+                                        
+                                        guard let email = user.kakaoAccount?.email else { return }
+                                        guard let profile = user.kakaoAccount?.profile?.profileImageUrl else {return}
+                                        User.shared.social = "KAKAO"
+                                        User.shared.uuid = uuid
+                                        User.shared.email = email
+                                        User.shared.profileImage = profile.absoluteString
+                                        
+                                    }
+                                }
+                                
+                                let kakaoConnectViewController = (KakaoConnectViewController())
+                                let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as! SceneDelegate
+                               sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: kakaoConnectViewController)
+//                                self.navigationController?.pushViewController(KakaoConnectViewController(), animated: true)
                             } else if data.status == 201 {
+                                guard let data = data.data else { return }
+                                KeychainHandler.shared.accessToken = data.accessToken
                                 self.navigationController?.pushViewController(YELLOTabBarController(), animated: true)
                             }
                         default:
                             print("network failure")
-                            
                             return
                         }
                     }
@@ -73,7 +95,7 @@ class KakaoLoginViewController: BaseViewController {
                             if data.status == 403 {
                                 UserApi.shared.me() {(user, error) in
                                     if let error = error {
-                                        print(error)
+                                        print("🚩🚩\(error)")
                                     } else {
                                         print("me() success.")
                                         _ = user

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/OnboardingEndViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/OnboardingEndViewController.swift
@@ -36,7 +36,7 @@ class OnboardingEndViewController: BaseViewController {
     
     private func postUserInfo() {
         let user = User.shared
-        let requestDTO = SignUpRequestDTO(social: user.social, uuid: user.uuid, email: user.email, profileImage: user.profileImage, groupID: user.groupId, groupAdmissionYear: user.groupAdmissionYear, name: user.name, yelloID: user.yelloId, gender: user.gender, friends: [])
+        let requestDTO = SignUpRequestDTO(social: user.social, uuid: user.uuid, email: user.email, profileImage: user.profileImage, groupID: user.groupId, groupAdmissionYear: user.groupAdmissionYear, name: user.name, yelloID: user.yelloId, gender: user.gender, friends: user.friends, recommendID: user.recommendId)
  
             NetworkService.shared.onboardingService.postUserInfo(requestDTO: requestDTO) { result in
                 switch result {


### PR DESCRIPTION
## ⛏ 작업 내용
- 추가될 친구 목록을 싱글톤에 저장하고 API로 넘겨주었습니다. 

## 📌 PR Point!
- 카카오 소셜 연결을 통해 카카오 친구를 받아오는 로직을 다음과 같이 구현했습니다. 
> 싱글톤에 `kakaoFriends`이라는 `String` 배열을 만들어서 저장했습니다. 
https://github.com/team-yello/YELLO-iOS/blob/8c5143497015270e21a70252fa50e5d9c159e06f/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/User.swift#L23
> 카카오 소셜 연결을 통해 카카오 친구를 불러왔습니다. 
https://github.com/team-yello/YELLO-iOS/blob/8c5143497015270e21a70252fa50e5d9c159e06f/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoConnectViewController.swift#L31-L42



## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 카카오톡 연결 화면 | ![Simulator_Screen_Recording_-_iPhone_SE__3rd_generation__-_2023-07-19_at_20_47_09_AdobeExpress (1)](https://github.com/team-yello/YELLO-iOS/assets/68178395/6c69253e-c205-4331-bbfa-f7f5123a6d64) |
|친구 추가된 화면|![Simulator Screenshot - iPhone SE (3rd generation) - 2023-07-19 at 20 48 01](https://github.com/team-yello/YELLO-iOS/assets/68178395/1fac0777-d9ec-496c-ab45-987bb9c4e744)|

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #91
