### PR TITLE
Fix [#104] 친구 수 4명 이하 로직 수정

### DIFF
--- a/YELLO-iOS/YELLO-iOS/Network/Base/APIRequestLoader.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Base/APIRequestLoader.swift
@@ -49,8 +49,8 @@ class APIRequestLoader<T: TargetType> {
     
     private func judgeStatus<M: Decodable>(by statusCode: Int, _ data: Data, type: M.Type) -> NetworkResult<M> {
         switch statusCode {
-        case 200, 201: return isValidData(data: data, type: M.self)
-        case 401...409: return isValidData(data: data, type: M.self)
+        case 200...299: return isValidData(data: data, type: M.self)
+        case 400...499: return isValidData(data: data, type: M.self)
         case 500: return .serverErr
         default: return .networkErr
         }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Voting/VotingLocked/VotingLockedViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Voting/VotingLocked/VotingLockedViewController.swift
@@ -17,7 +17,10 @@ final class VotingLockedViewController: BaseViewController {
     
     override func loadView() {
         self.view = originView
-        
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         getVotingAvailable()
     }
     

--- a/YELLO-iOS/YELLO-iOS/Presentation/Voting/VotingStart/VotingStartViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Voting/VotingStart/VotingStartViewController.swift
@@ -24,9 +24,8 @@ final class VotingStartViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        getVotingAvailable()
-        getVotingList()
+
+        getPoint()
         self.navigationController?.interactivePopGestureRecognizer?.isEnabled = false
     }
     
@@ -51,6 +50,9 @@ final class VotingStartViewController: BaseViewController {
         view.addSubview(animationView)
         
         tabBarController?.tabBar.isHidden = false
+        
+        getVotingAvailable()
+        getVotingList()
     }
     
     override func viewDidDisappear(_ animated: Bool) {
@@ -122,7 +124,7 @@ final class VotingStartViewController: BaseViewController {
 }
 
 extension VotingStartViewController {
-    func getVotingAvailable() {
+    func getPoint() {
         NetworkService.shared.votingService.getVotingAvailable {
             result in
             switch result {
@@ -158,6 +160,24 @@ extension VotingStartViewController {
                 }
                 self.votingList = votingList
                 
+            default:
+                print("network failure")
+                return
+            }
+        }
+    }
+    
+    func getVotingAvailable() {
+        NetworkService.shared.votingService.getVotingAvailable {
+            result in
+            print(result)
+            switch result {
+            case .success(let data):
+                let status = data.status
+                if status == 400 {
+                    let viewController = VotingLockedViewController()
+                    self.navigationController?.pushViewController(viewController, animated: true)
+                }
             default:
                 print("network failure")
                 return


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- VotingStartViewController에서 viewWillAppear시 서버통신을 해서 친구 수가 4명 이상인지 다시 판단할 수 있도록 로직을 수정했습니다.

<!--
```
작성한 코드가 있다면 여기에 주석을 제거하고 적어주세요!
```
-->


## 📌 PR Point!
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- Network Base의 APIRequestLoader파일을 아래와 같이 수정했습니다 ‼️
- StatusCode case를 200...299, 400...499로 수정했습니당!
https://github.com/team-yello/YELLO-iOS/blob/0892d13cbf5ad559a14955c922c80585e31081a9/YELLO-iOS/YELLO-iOS/Network/Base/APIRequestLoader.swift#L50-L57

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 화면종류 | 파일첨부바람 |


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #104
