### PR TITLE
Fix [#109] 포인트 레이아웃

### DIFF
--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/GetHintView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/GetHintView.swift
@@ -70,13 +70,13 @@ final class GetHintView: BaseView {
         }
         
         pointLabel.do {
-            $0.setTextWithLineHeight(text: " ", lineHeight: 20)
             $0.textColor = .white
             $0.font = .uiKeywordBold
+            $0.textAlignment = .right
         }
         
         pointTextLabel.do {
-            $0.setTextWithLineHeight(text: StringLiterals.MyYello.Alert.point, lineHeight: 20)
+            $0.text = StringLiterals.MyYello.Alert.point
             $0.textColor = .grayscales400
             $0.font = .uiBodySmall
         }
@@ -138,12 +138,13 @@ final class GetHintView: BaseView {
         
         pointLabel.snp.makeConstraints {
             $0.trailing.equalTo(pointTextLabel.snp.leading).inset(-4)
-            $0.centerY.equalToSuperview()
+            $0.centerY.equalTo(pointTitleLabel)
+            $0.width.equalTo(65)
         }
         
         pointTextLabel.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(16)
-            $0.centerY.equalToSuperview()
+            $0.centerY.equalTo(pointTitleLabel)
         }
         
         confirmButton.snp.makeConstraints {

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/MyYelloDetailNavigationBarView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/MyYelloDetailNavigationBarView.swift
@@ -68,11 +68,12 @@ final class MyYelloDetailNavigationBarView: BaseView {
         
         pointImageView.snp.makeConstraints {
             $0.centerY.equalTo(backButton)
-            $0.trailing.equalToSuperview().inset(61)
+//            $0.trailing.equalToSuperview().inset(61)
         }
         
         pointLabel.snp.makeConstraints {
             $0.centerY.equalTo(backButton)
+            $0.trailing.equalToSuperview().inset(16)
             $0.leading.equalTo(pointImageView.snp.trailing).inset(-8)
         }
     }

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/MyYelloDetailNavigationBarView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/MyYelloDetailNavigationBarView.swift
@@ -68,7 +68,6 @@ final class MyYelloDetailNavigationBarView: BaseView {
         
         pointImageView.snp.makeConstraints {
             $0.centerY.equalTo(backButton)
-//            $0.trailing.equalToSuperview().inset(61)
         }
         
         pointLabel.snp.makeConstraints {

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/PointLackView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/PointLackView.swift
@@ -68,13 +68,14 @@ final class PointLackView: BaseView {
         }
         
         pointLabel.do {
-            $0.setTextWithLineHeight(text: "2350", lineHeight: 20)
+            $0.text = "0"
             $0.textColor = .white
             $0.font = .uiKeywordBold
+            $0.textAlignment = .right
         }
         
         pointTextLabel.do {
-            $0.setTextWithLineHeight(text: StringLiterals.MyYello.Alert.point, lineHeight: 20)
+            $0.text = StringLiterals.MyYello.Alert.point
             $0.textColor = .grayscales400
             $0.font = .uiBodySmall
         }
@@ -135,12 +136,13 @@ final class PointLackView: BaseView {
         
         pointLabel.snp.makeConstraints {
             $0.trailing.equalTo(pointTextLabel.snp.leading).inset(-4)
-            $0.centerY.equalToSuperview()
+            $0.centerY.equalTo(pointTitleLabel)
+            $0.width.equalTo(103)
         }
         
         pointTextLabel.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(16)
-            $0.centerY.equalToSuperview()
+            $0.centerY.equalTo(pointTitleLabel)
         }
         
         yelloButton.snp.makeConstraints {

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/UsePointView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/UsePointView.swift
@@ -62,13 +62,13 @@ final class UsePointView: BaseView {
         }
         
         pointLabel.do {
-            $0.setTextWithLineHeight(text: " ", lineHeight: 20)
             $0.textColor = .white
             $0.font = .uiKeywordBold
+            $0.textAlignment = .right
         }
         
         pointTextLabel.do {
-            $0.setTextWithLineHeight(text: StringLiterals.MyYello.Alert.point, lineHeight: 20)
+            $0.text =  StringLiterals.MyYello.Alert.point
             $0.textColor = .grayscales400
             $0.font = .uiBodySmall
         }
@@ -133,12 +133,13 @@ final class UsePointView: BaseView {
         
         pointLabel.snp.makeConstraints {
             $0.trailing.equalTo(pointTextLabel.snp.leading).inset(-4)
-            $0.centerY.equalToSuperview()
+            $0.centerY.equalTo(pointTitleLabel)
+            $0.width.equalTo(103)
         }
         
         pointTextLabel.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(16)
-            $0.centerY.equalToSuperview()
+            $0.centerY.equalTo(pointTitleLabel)
         }
         
         confirmButton.snp.makeConstraints {

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/View/MyYelloNavigationBarView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/View/MyYelloNavigationBarView.swift
@@ -30,13 +30,13 @@ final class MyYelloNavigationBarView: BaseView {
         }
         
         yelloNumberLabel.do {
-            $0.setTextWithLineHeight(text: StringLiterals.MyYello.NavigationBar.yelloNumber, lineHeight: 16)
+            $0.text = StringLiterals.MyYello.NavigationBar.yelloNumber
             $0.font = .uiLabelLarge
             $0.textColor = .grayscales500
         }
         
         yelloCountLabel.do {
-            $0.setTextWithLineHeight(text: "개", lineHeight: 16)
+            $0.text = "0개"
             $0.font = .uiLabelLarge
             $0.textColor = .grayscales200
             $0.asColor(targetString: "개", color: .grayscales500)

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/ViewController/MyYelloViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/ViewController/MyYelloViewController.swift
@@ -101,8 +101,6 @@ extension MyYelloViewController {
 
         NetworkService.shared.myYelloService.myYello(queryDTO: queryDTO) { [weak self] response in
             guard let self = self else { return }
-
-//            DispatchQueue.main.async {
                 switch response {
                 case .success(let data):
                     guard let data = data.data else { return }
@@ -115,7 +113,6 @@ extension MyYelloViewController {
                     print("network fail")
                     return
                 }
-//            }
         }
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/FriendCountView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/FriendCountView.swift
@@ -48,13 +48,13 @@ extension FriendCountView {
         }
         
         friendNumberLabel.do {
-            $0.setTextWithLineHeight(text: StringLiterals.Profile.FriendCount.friendNumber, lineHeight: 16)
+            $0.text = StringLiterals.Profile.FriendCount.friendNumber
             $0.font = .uiLabelLarge
             $0.textColor = .grayscales500
         }
         
         friendCountLabel.do {
-            $0.setTextWithLineHeight(text: "0명", lineHeight: 16)
+            $0.text = "0명"
             $0.font = .uiLabelLarge
             $0.textColor = .grayscales300
             $0.asColor(targetString: "명", color: .grayscales500)

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/ProfileView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/ProfileView.swift
@@ -235,6 +235,7 @@ extension ProfileView: UITableViewDataSource {
                 view?.addBottomBorderWithColor(color: .black)
                 view?.myProfileView.profileUser()
                 view?.friendCountView.friendCountLabel.text = String(self.friendCount) + "명"
+                view?.friendCountView.friendCountLabel.asColor(targetString: "명", color: .grayscales500)
             }
             return view
         default:


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 포인트가 아주 많아졌을 때의 레이아웃을 재설정 했습니다. 9억 기준으로 맞췄습니다.. 10억이 넘지 않길 바랄뿐
- 내 프로필과 내 친구 부분 토탈 카운트 레이아웃 수정했습니다.
<!--
```
작성한 코드가 있다면 여기에 주석을 제거하고 적어주세요!
```
-->


## 📌 PR Point!
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 없슴둥 ㅋㅋ


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    내 프로필 토탈 카운트   |   내 옐로 토탈 카운트   | 내 옐로 포인트 사용 시 레이아웃 |
| :-------------: | :----------: | :----------: |
| ![IMG_1922](https://github.com/team-yello/YELLO-iOS/assets/109775321/9bc9eec5-1afc-45d6-b050-c09eace9d5c7) | ![IMG_1923](https://github.com/team-yello/YELLO-iOS/assets/109775321/4ea854f7-1a5c-4457-87aa-8fc2230a71d6) | ![ezgif-3-0ba0da09ba](https://github.com/team-yello/YELLO-iOS/assets/109775321/9508dc7d-d7a8-4d8e-abe9-4cc912c782f5) |



### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #109 
