### PR TITLE
Fix [101] iOS 15 이하 기기 대응 

### DIFF
--- a/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
+++ b/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
@@ -57,6 +57,9 @@
 		3628EAEA2A60903A00D5FA40 /* splash.json in Resources */ = {isa = PBXBuildFile; fileRef = 3628EAE92A60903A00D5FA40 /* splash.json */; };
 		3628EAEC2A609E1D00D5FA40 /* SplashTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3628EAEB2A609E1D00D5FA40 /* SplashTitleView.swift */; };
 		36621BCD2A690B2400010D84 /* BaseBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36621BCC2A690B2400010D84 /* BaseBottomSheetViewController.swift */; };
+		36621BCF2A692A7700010D84 /* StudentIdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36621BCE2A692A7700010D84 /* StudentIdView.swift */; };
+		36621BD12A69318200010D84 /* StudentIdViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36621BD02A69318200010D84 /* StudentIdViewController.swift */; };
+		36621BD32A693D4C00010D84 /* BottomFriendProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36621BD22A693D4C00010D84 /* BottomFriendProfileViewController.swift */; };
 		3662A0E42A63F6C300F482EF /* CheckDuplicateResponeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3662A0E32A63F6C300F482EF /* CheckDuplicateResponeDTO.swift */; };
 		3662A0E82A64414800F482EF /* OnboardingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3662A0E72A64414800F482EF /* OnboardingService.swift */; };
 		3662A0EA2A64437900F482EF /* KakaoLoginRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3662A0E92A64437900F482EF /* KakaoLoginRequestDTO.swift */; };
@@ -102,7 +105,6 @@
 		36E427812A5BD60A0050B34E /* SchoolSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E427802A5BD60A0050B34E /* SchoolSearchView.swift */; };
 		36E427832A5BD6110050B34E /* StudentInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E427822A5BD6110050B34E /* StudentInfoView.swift */; };
 		36E427852A5BD6160050B34E /* UserInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E427842A5BD6160050B34E /* UserInfoView.swift */; };
-		36E4278B2A5C7C010050B34E /* StudentIdViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E4278A2A5C7C010050B34E /* StudentIdViewController.swift */; };
 		36E4278D2A5C92EC0050B34E /* FindMajorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E4278C2A5C92EC0050B34E /* FindMajorViewController.swift */; };
 		36E4278F2A5C93CE0050B34E /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E4278E2A5C93CE0050B34E /* SearchView.swift */; };
 		36E427912A5C9BD20050B34E /* RecommendIdViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E427902A5C9BD20050B34E /* RecommendIdViewController.swift */; };
@@ -274,6 +276,9 @@
 		3628EAE92A60903A00D5FA40 /* splash.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = splash.json; sourceTree = "<group>"; };
 		3628EAEB2A609E1D00D5FA40 /* SplashTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashTitleView.swift; sourceTree = "<group>"; };
 		36621BCC2A690B2400010D84 /* BaseBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBottomSheetViewController.swift; sourceTree = "<group>"; };
+		36621BCE2A692A7700010D84 /* StudentIdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentIdView.swift; sourceTree = "<group>"; };
+		36621BD02A69318200010D84 /* StudentIdViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StudentIdViewController.swift; sourceTree = "<group>"; };
+		36621BD22A693D4C00010D84 /* BottomFriendProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomFriendProfileViewController.swift; sourceTree = "<group>"; };
 		3662A0E22A63474000F482EF /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		3662A0E32A63F6C300F482EF /* CheckDuplicateResponeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckDuplicateResponeDTO.swift; sourceTree = "<group>"; };
 		3662A0E72A64414800F482EF /* OnboardingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingService.swift; sourceTree = "<group>"; };
@@ -320,7 +325,6 @@
 		36E427802A5BD60A0050B34E /* SchoolSearchView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SchoolSearchView.swift; sourceTree = "<group>"; };
 		36E427822A5BD6110050B34E /* StudentInfoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StudentInfoView.swift; sourceTree = "<group>"; };
 		36E427842A5BD6160050B34E /* UserInfoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInfoView.swift; sourceTree = "<group>"; };
-		36E4278A2A5C7C010050B34E /* StudentIdViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentIdViewController.swift; sourceTree = "<group>"; };
 		36E4278C2A5C92EC0050B34E /* FindMajorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindMajorViewController.swift; sourceTree = "<group>"; };
 		36E4278E2A5C93CE0050B34E /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		36E427902A5C9BD20050B34E /* RecommendIdViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendIdViewController.swift; sourceTree = "<group>"; };
@@ -935,7 +939,7 @@
 				36E427782A5BD5C90050B34E /* SchoolSearchViewController.swift */,
 				36E427762A5BD5AA0050B34E /* FindSchoolViewController.swift */,
 				36E4277A2A5BD5D00050B34E /* StudentInfoViewController.swift */,
-				36E4278A2A5C7C010050B34E /* StudentIdViewController.swift */,
+				36621BD02A69318200010D84 /* StudentIdViewController.swift */,
 				36E4278C2A5C92EC0050B34E /* FindMajorViewController.swift */,
 				36E4277C2A5BD5D60050B34E /* UserInfoViewController.swift */,
 				36E4275B2A5BCE860050B34E /* GenderViewController.swift */,
@@ -969,6 +973,7 @@
 				36E427962A5CA5AF0050B34E /* OnboardingEndView.swift */,
 				36B2349B2A61A22F007933E4 /* KakaoLoginView.swift */,
 				36B2349F2A61A6BC007933E4 /* KakaoConnectView.swift */,
+				36621BCE2A692A7700010D84 /* StudentIdView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1221,6 +1226,7 @@
 			children = (
 				2AA0DBB72A546E93002B1370 /* ProfileViewController.swift */,
 				C3FF24762A5D796B00A97D40 /* FriendProfileViewController.swift */,
+				36621BD22A693D4C00010D84 /* BottomFriendProfileViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -1481,6 +1487,7 @@
 				C307ECB62A607357000F5BA9 /* FriendCountView.swift in Sources */,
 				C3FF248A2A5E845A00A97D40 /* MyYelloEmptyView.swift in Sources */,
 				2AA0DBB02A546E1D002B1370 /* RecommendingViewController.swift in Sources */,
+				36621BD32A693D4C00010D84 /* BottomFriendProfileViewController.swift in Sources */,
 				36871C7D2A664CD8001CA514 /* JoinedFriendsRequestQueryDTO.swift in Sources */,
 				36621BCD2A690B2400010D84 /* BaseBottomSheetViewController.swift in Sources */,
 				C3FF24902A5E8ED000A97D40 /* MyYelloListView.swift in Sources */,
@@ -1489,6 +1496,7 @@
 				2A3705AA2A62DC9F001AAC93 /* APIRequestLoader.swift in Sources */,
 				36E427912A5C9BD20050B34E /* RecommendIdViewController.swift in Sources */,
 				C3A799E22A494D6800D3EFD8 /* UIButton+.swift in Sources */,
+				36621BD12A69318200010D84 /* StudentIdViewController.swift in Sources */,
 				C3FF24A22A5EEBD600A97D40 /* DetailKeywordView.swift in Sources */,
 				2AD1A1B42A5739B300CB988B /* InvitingView.swift in Sources */,
 				C3DC4AD82A5FDF4B001DCE04 /* PaymentReadyViewController.swift in Sources */,
@@ -1507,6 +1515,7 @@
 				C3A799E82A494D6800D3EFD8 /* UILabel+.swift in Sources */,
 				2AA0DBC32A553788002B1370 /* YELLOTabBarController.swift in Sources */,
 				C3C57BF32A5C089600B84CAA /* FriendTableViewCell.swift in Sources */,
+				36621BCF2A692A7700010D84 /* StudentIdView.swift in Sources */,
 				C3A799BE2A494AFD00D3EFD8 /* Image.swift in Sources */,
 				C3C57BC72A57160000B84CAA /* SchoolFriendViewController.swift in Sources */,
 				36E4278F2A5C93CE0050B34E /* SearchView.swift in Sources */,
@@ -1569,7 +1578,6 @@
 				36E427732A5BCE860050B34E /* YelloTextField.swift in Sources */,
 				2A3705CA2A62E2A2001AAC93 /* KakaoLoginResponseDTO.swift in Sources */,
 				C3FF249E2A5EE48200A97D40 /* MyYelloDetailView.swift in Sources */,
-				36E4278B2A5C7C010050B34E /* StudentIdViewController.swift in Sources */,
 				2AD1A1D42A5C3FC200CB988B /* VotingDummy.swift in Sources */,
 				C3B472122A65E17E00770530 /* MyYelloDetailNameResponseDTO.swift in Sources */,
 				C3D2664C2A5D1F4C0041C7C7 /* ProfileSettingViewController.swift in Sources */,
@@ -1739,7 +1747,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				NEW_SETTING = "";
@@ -1796,7 +1804,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				NEW_SETTING = "";
@@ -1825,7 +1833,7 @@
 				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1858,7 +1866,7 @@
 				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
+++ b/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		3628EAE82A608F0200D5FA40 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3628EAE72A608F0200D5FA40 /* SplashViewController.swift */; };
 		3628EAEA2A60903A00D5FA40 /* splash.json in Resources */ = {isa = PBXBuildFile; fileRef = 3628EAE92A60903A00D5FA40 /* splash.json */; };
 		3628EAEC2A609E1D00D5FA40 /* SplashTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3628EAEB2A609E1D00D5FA40 /* SplashTitleView.swift */; };
+		36621BCD2A690B2400010D84 /* BaseBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36621BCC2A690B2400010D84 /* BaseBottomSheetViewController.swift */; };
 		3662A0E42A63F6C300F482EF /* CheckDuplicateResponeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3662A0E32A63F6C300F482EF /* CheckDuplicateResponeDTO.swift */; };
 		3662A0E82A64414800F482EF /* OnboardingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3662A0E72A64414800F482EF /* OnboardingService.swift */; };
 		3662A0EA2A64437900F482EF /* KakaoLoginRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3662A0E92A64437900F482EF /* KakaoLoginRequestDTO.swift */; };
@@ -272,6 +273,7 @@
 		3628EAE72A608F0200D5FA40 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		3628EAE92A60903A00D5FA40 /* splash.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = splash.json; sourceTree = "<group>"; };
 		3628EAEB2A609E1D00D5FA40 /* SplashTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashTitleView.swift; sourceTree = "<group>"; };
+		36621BCC2A690B2400010D84 /* BaseBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBottomSheetViewController.swift; sourceTree = "<group>"; };
 		3662A0E22A63474000F482EF /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		3662A0E32A63F6C300F482EF /* CheckDuplicateResponeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckDuplicateResponeDTO.swift; sourceTree = "<group>"; };
 		3662A0E72A64414800F482EF /* OnboardingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingService.swift; sourceTree = "<group>"; };
@@ -1143,6 +1145,7 @@
 				C3A799CA2A494C7500D3EFD8 /* BaseViewController.swift */,
 				C3FF24B22A5F4D1F00A97D40 /* BasePaddingLabel.swift */,
 				C3A799CC2A494C8600D3EFD8 /* BaseView.swift */,
+				36621BCC2A690B2400010D84 /* BaseBottomSheetViewController.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -1479,6 +1482,7 @@
 				C3FF248A2A5E845A00A97D40 /* MyYelloEmptyView.swift in Sources */,
 				2AA0DBB02A546E1D002B1370 /* RecommendingViewController.swift in Sources */,
 				36871C7D2A664CD8001CA514 /* JoinedFriendsRequestQueryDTO.swift in Sources */,
+				36621BCD2A690B2400010D84 /* BaseBottomSheetViewController.swift in Sources */,
 				C3FF24902A5E8ED000A97D40 /* MyYelloListView.swift in Sources */,
 				36E427702A5BCE860050B34E /* YelloButton.swift in Sources */,
 				C3B472102A65E0A200770530 /* MyYelloDetailKeywordResponseDTO.swift in Sources */,
@@ -1821,7 +1825,7 @@
 				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1854,7 +1858,7 @@
 				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/YELLO-iOS/YELLO-iOS/Presentation/Base/BaseBottomSheetViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Base/BaseBottomSheetViewController.swift
@@ -1,0 +1,134 @@
+//
+//  BaseBottomSheetViewController.swift
+//  YELLO-iOS
+//
+//  Created by 지희의 MAC on 2023/07/20.
+//
+import UIKit
+import SnapKit
+
+protocol LoginNameDataBindProtocol: AnyObject {
+    func nicknameDataBind(text: String)
+}
+
+
+final class BottomSheetViewController: UIViewController {
+    
+    var defaultHeight: CGFloat = Constant.Screen.height.isHalf
+    weak var delegate: LoginNameDataBindProtocol?
+    
+    //MARK: UIComponent
+    private let dimmedView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.darkGray.withAlphaComponent(0.7)
+        return view
+    }()
+    
+    private let bottomSheetView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.layer.cornerRadius = 10
+        view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        view.clipsToBounds = true
+        return view
+    }()
+    
+    
+    //MARK: life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUI()
+        addTarget()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        showBottomSheet()
+    }
+    
+    //MARK: Custom Method
+    
+    private func showBottomSheet() {
+        bottomSheetView.snp.remakeConstraints{
+            $0.height.equalTo(defaultHeight)
+            $0.leading.trailing.bottom.equalToSuperview()
+            $0.top.equalToSuperview().inset(defaultHeight)
+        }
+        UIView.animate(withDuration: 1.0, animations: {
+            self.view.layoutIfNeeded()
+        }, completion: nil)
+        
+    }
+    
+    private func hideBottomSheetAndGoBack() {
+        bottomSheetView.snp.remakeConstraints {
+            $0.height.equalTo(defaultHeight)
+            $0.top.equalTo(view.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+        }
+        
+        UIView.animate(withDuration: 1.0, animations: {
+            self.view.layoutIfNeeded()
+            self.dimmedView.alpha = 0.0
+        }){ _ in
+            if self.presentingViewController != nil {
+                self.dismiss(animated: false, completion: nil)
+            }
+        }
+        
+        if let text = nicknameSettingView.nickNameTextField.text {
+            delegate?.nicknameDataBind(text: text)
+        }
+    }
+    
+    private func addTarget(){
+        nicknameSettingView.settingButton.addTarget(self, action: #selector(settingButtonDidTap), for: .touchUpInside)
+        
+        let dimmedTap = UITapGestureRecognizer(target: self, action: #selector(dimmedViewTapped(_:)))
+        dimmedView.addGestureRecognizer(dimmedTap)
+        dimmedView.isUserInteractionEnabled = true
+    }
+    
+    //MARK: Action
+    
+    @objc func settingButtonDidTap(){
+        hideBottomSheetAndGoBack()
+    }
+    
+    @objc private func dimmedViewTapped(_ tapRecognizer: UITapGestureRecognizer) {
+        hideBottomSheetAndGoBack()
+    }
+    
+    
+}
+
+private extension BottomSheetViewController {
+    func setUI(){
+        setViewHierarchy()
+        setLayout()
+    }
+    
+    func setViewHierarchy(){
+        view.addSubviews(dimmedView,bottomSheetView)
+        bottomSheetView.addSubview(nicknameSettingView)
+        //bottomSheetView.addSubviews(nickNameLabel,nickNameTextField,settingButton)
+    }
+    
+    func setLayout(){
+        dimmedView.snp.makeConstraints{
+            $0.edges.equalToSuperview()
+        }
+        
+        bottomSheetView.snp.makeConstraints{
+            $0.height.equalTo(defaultHeight)
+            $0.top.equalTo(view.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+        }
+        
+        nicknameSettingView.snp.makeConstraints{
+            $0.edges.equalToSuperview()
+        }
+        
+        
+    }
+}

--- a/YELLO-iOS/YELLO-iOS/Presentation/Base/BaseBottomSheetViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Base/BaseBottomSheetViewController.swift
@@ -7,32 +7,25 @@
 import UIKit
 import SnapKit
 
-protocol LoginNameDataBindProtocol: AnyObject {
-    func nicknameDataBind(text: String)
-}
-
-
-final class BottomSheetViewController: UIViewController {
+class BaseBottomViewController: UIViewController {
     
-    var defaultHeight: CGFloat = Constant.Screen.height.isHalf
-    weak var delegate: LoginNameDataBindProtocol?
+    var height = UIScreen.main.bounds.height
+    lazy var defaultHeight: CGFloat = (height)/2
     
-    //MARK: UIComponent
+    // MARK: UIComponent
     private let dimmedView: UIView = {
         let view = UIView()
-        view.backgroundColor = UIColor.darkGray.withAlphaComponent(0.7)
+        view.backgroundColor = UIColor.grayscales900.withAlphaComponent(0.4)
         return view
     }()
     
-    private let bottomSheetView: UIView = {
+    let bottomSheetView: UIView = {
         let view = UIView()
-        view.backgroundColor = .white
         view.layer.cornerRadius = 10
         view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         view.clipsToBounds = true
         return view
     }()
-    
     
     //MARK: life Cycle
     override func viewDidLoad() {
@@ -46,15 +39,44 @@ final class BottomSheetViewController: UIViewController {
         showBottomSheet()
     }
     
-    //MARK: Custom Method
+    func setUI() {
+        setViewHierarchy()
+        setLayout()
+    }
+    
+    func setViewHierarchy( ) {
+        view.addSubviews(dimmedView, bottomSheetView)
+    }
+    
+    func setLayout() {
+        dimmedView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        bottomSheetView.snp.makeConstraints {
+            $0.height.equalTo(defaultHeight)
+            $0.top.equalTo(view.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+        }
+        
+    }
+    
+    // MARK: Custom Method
+    func setCustomView(view: UIView) {
+        bottomSheetView.addSubview(view)
+        view.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
     
     private func showBottomSheet() {
-        bottomSheetView.snp.remakeConstraints{
+        dimmedView.isHidden = false
+        bottomSheetView.snp.remakeConstraints {
             $0.height.equalTo(defaultHeight)
             $0.leading.trailing.bottom.equalToSuperview()
             $0.top.equalToSuperview().inset(defaultHeight)
         }
-        UIView.animate(withDuration: 1.0, animations: {
+        UIView.animate(withDuration: 0.4, animations: {
             self.view.layoutIfNeeded()
         }, completion: nil)
         
@@ -67,31 +89,24 @@ final class BottomSheetViewController: UIViewController {
             $0.leading.trailing.equalToSuperview()
         }
         
-        UIView.animate(withDuration: 1.0, animations: {
+        UIView.animate(withDuration: 0.5, animations: {
             self.view.layoutIfNeeded()
-            self.dimmedView.alpha = 0.0
+            self.dimmedView.isHidden = true
         }){ _ in
             if self.presentingViewController != nil {
-                self.dismiss(animated: false, completion: nil)
+               self.dismiss(animated: false, completion: nil)
             }
-        }
-        
-        if let text = nicknameSettingView.nickNameTextField.text {
-            delegate?.nicknameDataBind(text: text)
         }
     }
     
-    private func addTarget(){
-        nicknameSettingView.settingButton.addTarget(self, action: #selector(settingButtonDidTap), for: .touchUpInside)
-        
+    private func addTarget() {
         let dimmedTap = UITapGestureRecognizer(target: self, action: #selector(dimmedViewTapped(_:)))
         dimmedView.addGestureRecognizer(dimmedTap)
         dimmedView.isUserInteractionEnabled = true
     }
     
-    //MARK: Action
-    
-    @objc func settingButtonDidTap(){
+    // MARK: Action
+    @objc func settingButtonDidTap() {
         hideBottomSheetAndGoBack()
     }
     
@@ -99,36 +114,4 @@ final class BottomSheetViewController: UIViewController {
         hideBottomSheetAndGoBack()
     }
     
-    
-}
-
-private extension BottomSheetViewController {
-    func setUI(){
-        setViewHierarchy()
-        setLayout()
-    }
-    
-    func setViewHierarchy(){
-        view.addSubviews(dimmedView,bottomSheetView)
-        bottomSheetView.addSubview(nicknameSettingView)
-        //bottomSheetView.addSubviews(nickNameLabel,nickNameTextField,settingButton)
-    }
-    
-    func setLayout(){
-        dimmedView.snp.makeConstraints{
-            $0.edges.equalToSuperview()
-        }
-        
-        bottomSheetView.snp.makeConstraints{
-            $0.height.equalTo(defaultHeight)
-            $0.top.equalTo(view.snp.bottom)
-            $0.leading.trailing.equalToSuperview()
-        }
-        
-        nicknameSettingView.snp.makeConstraints{
-            $0.edges.equalToSuperview()
-        }
-        
-        
-    }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/Base/OnboardingViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/Base/OnboardingViewController.swift
@@ -18,6 +18,7 @@ class OnboardingBaseViewController: BaseViewController {
     private let backButton = UIButton()
     let nextButton = YelloButton(buttonText: "다음")
     private let skipButton = UIButton()
+    let navigationBarView = UIView()
     var nextViewController: UIViewController?
     var isSkipable = false
     
@@ -26,12 +27,17 @@ class OnboardingBaseViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(false, animated: true)
+        
     }
     
     override func viewDidLoad() {
-        setNavigationBarAppearance()
-        super.viewDidLoad()
         configUI()
+        super.viewDidLoad()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        view.bringSubviewToFront(nextButton)
     }
     
     // MARK: - Function
@@ -69,7 +75,7 @@ class OnboardingBaseViewController: BaseViewController {
             $0.bottom.equalTo(nextButton.snp.top).inset(-14)
             $0.centerX.equalToSuperview()
         }
-
+        
     }
     
     func makeBarButtonItem<T: UIView>(with view: T) -> UIBarButtonItem {
@@ -79,14 +85,25 @@ class OnboardingBaseViewController: BaseViewController {
     func setNavigationBarAppearance() {
         let backButtonImage = ImageLiterals.OnBoarding.icArrowLeft.withTintColor(.white, renderingMode: .alwaysOriginal)
         let appearance = UINavigationBarAppearance()
-        appearance.setBackIndicatorImage(backButtonImage, transitionMaskImage: backButtonImage)
-        appearance.backButtonAppearance.normal.titlePositionAdjustment = UIOffset(horizontal: -200, vertical: 0)
-        appearance.backgroundColor = .black
-        appearance.shadowColor = .clear
-        navigationItem.standardAppearance = appearance
-        navigationItem.compactAppearance = appearance
-        navigationItem.scrollEdgeAppearance = appearance
-        
+        if #available(iOS 15.0, *) {
+            appearance.setBackIndicatorImage(backButtonImage, transitionMaskImage: backButtonImage)
+            appearance.backButtonAppearance.normal.titlePositionAdjustment = UIOffset(horizontal: -200, vertical: 0)
+            appearance.backgroundColor = .black
+            appearance.shadowColor = .clear
+            navigationItem.standardAppearance = appearance
+            navigationItem.compactAppearance = appearance
+            navigationItem.scrollEdgeAppearance = appearance
+        } else {
+            // 타이틀 숨기기
+               navigationItem.title = ""
+               
+               // 배경을 투명색으로 설정
+               navigationController?.navigationBar.setBackgroundImage(UIImage(), for: .default)
+               navigationController?.navigationBar.shadowImage = UIImage()
+               
+               // BackButton 커스텀
+               navigationItem.leftBarButtonItem = UIBarButtonItem(image: backButtonImage, style: .plain, target: self, action: #selector(backButtonTapped))
+        }
     }
     
     func setUser() {}
@@ -98,6 +115,15 @@ class OnboardingBaseViewController: BaseViewController {
             self.navigationController?.pushViewController(nextViewController, animated: true)
         } else {}
         
+    }
+    
+    @objc private func backButtonTapped() {
+        // BackButton 동작 처리
+        navigationController?.popViewController(animated: true)
+    }
+    
+    @objc func didTapBackButton() {
+        navigationController?.popViewController(animated: true)
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/SchoolSearchViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/SchoolSearchViewController.swift
@@ -46,14 +46,9 @@ final class SchoolSearchViewController: OnboardingBaseViewController {
     
     private func presentModal() {
         let findSchooViewController = FindSchoolViewController()
-        let nav = UINavigationController(rootViewController: findSchooViewController)
-        nav.modalPresentationStyle = .pageSheet
-        if let sheet = nav.sheetPresentationController {
-            sheet.detents = [.large()]
-        }
-        present(nav, animated: true, completion: nil)
+        self.present(findSchooViewController, animated: true)
     }
-        
+    
     // MARK: objc Function
     @objc func didTapTextField() {
         presentModal()

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/StudentInfoViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/StudentInfoViewController.swift
@@ -10,11 +10,14 @@ import UIKit
 import SnapKit
 import Then
 
+
 class StudentInfoViewController: OnboardingBaseViewController {
     
     // MARK: - Variables
     let majorSearchViewController = FindMajorViewController()
     let studentIdViewController = StudentIdViewController()
+    let bottomSheet = BaseBottomViewController()
+    let studentIdView = StudentIdView()
     
     // MARK: Component
     private let baseView = StudentInfoView()
@@ -25,6 +28,7 @@ class StudentInfoViewController: OnboardingBaseViewController {
     }
     var groupId = 0
     var groupAdmissionYear = 0
+    weak var delegate: SelectStudentIdDelegate?
     
     // MARK: - Function
     // MARK: LifeCycle
@@ -50,7 +54,7 @@ class StudentInfoViewController: OnboardingBaseViewController {
         baseView.majorTextField.textField.delegate = self
         baseView.studentIDTextField.textField.delegate = self
         majorSearchViewController.majorDelegate = self
-        studentIdViewController.delegate = self
+        studentIdView.idDelegate = self
     }
     
     private func resetTextField() {
@@ -67,16 +71,21 @@ class StudentInfoViewController: OnboardingBaseViewController {
     
     private func presentModal() {
         
-        let nav = UINavigationController(rootViewController: studentIdViewController)
-        studentIdViewController.delegate = self
-        
-        if let sheet = nav.sheetPresentationController {
-            sheet.detents = [.medium()]
-            sheet.prefersGrabberVisible = true
-            sheet.invalidateDetents()
+        if #available(iOS 15.0, *) {
+            let nav = UINavigationController(rootViewController: studentIdViewController)
+            if let sheet = nav.sheetPresentationController {
+                sheet.detents = [.medium()]
+                sheet.prefersGrabberVisible = true
+                if #available(iOS 16.0, *) {
+                    sheet.invalidateDetents()
+                }
+            }
+        } else {
+            
+            bottomSheet.setCustomView(view: studentIdView)
+            bottomSheet.modalPresentationStyle = .overFullScreen
+            present(bottomSheet, animated: false)
         }
-        
-        present(nav, animated: true, completion: nil)
     }
     
     func checkButtonEnable() {
@@ -97,7 +106,7 @@ class StudentInfoViewController: OnboardingBaseViewController {
         User.shared.groupId = groupId
         User.shared.groupAdmissionYear = groupAdmissionYear
     }
-
+    
 }
 
 // MARK: - extension
@@ -112,6 +121,7 @@ extension StudentInfoViewController: UITextFieldDelegate {
             self.present(nextViewController, animated: true)
         case baseView.studentIDTextField.textField:
             textField.resignFirstResponder()
+            
             presentModal()
         default:
             return
@@ -140,6 +150,24 @@ extension StudentInfoViewController: SelectStudentIdDelegate {
         baseView.studentIDTextField.textField.text = "\(result)학번"
         groupAdmissionYear = result
         checkButtonEnable()
+        bottomSheet.dismiss(animated: false)
+    }
+}
+
+
+// MARK: StudentIdView
+extension StudentInfoViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let currentCell = tableView.cellForRow(at: indexPath),
+              let cellTitle = currentCell.textLabel?.text else {
+            return
+        }
+        
+        // 학번 문자열에서 숫자 부분 추출
+        let studentId = cellTitle.components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
+        guard let studentId = Int(studentId) else { return }
+        delegate?.didSelectStudentId(studentId)
+        self.dismiss(animated: true)
     }
 }
 

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/StudentIdView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/StudentIdView.swift
@@ -1,0 +1,73 @@
+//
+//  StudentIdView.swift
+//  YELLO-iOS
+//
+//  Created by 지희의 MAC on 2023/07/20.
+//
+
+import UIKit
+
+class StudentIdView: BaseView {
+    // MARK: - Variables
+    // MARK: Constants
+    let studentIdList = (15...23).reversed().map { "\($0)학번" }
+    let studentIdTableView = UITableView()
+    
+    // MARK: Property
+    weak var idDelegate: SelectStudentIdDelegate?
+    
+    override func setStyle() {
+        self.addSubview(studentIdTableView)
+        self.backgroundColor = .grayscales900
+        studentIdTableView.do {
+            $0.delegate = self
+            $0.dataSource = self
+            $0.rowHeight = 42 // 셀의 높이를 42로 설정
+            $0.backgroundColor = .grayscales900
+            $0.separatorStyle = .none
+            $0.tableHeaderView = UIView()
+        }
+    }
+    
+    override func setLayout() {
+        studentIdTableView.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(24)
+        }
+    }
+}
+
+// MARK: - extension
+// MARK: UITableViewDataSource
+extension StudentIdView: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        studentIdList.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = UITableViewCell(style: .default, reuseIdentifier: .none)
+        cell.textLabel?.text = studentIdList[indexPath.row]
+        cell.textLabel?.font = .uiBodyLarge
+        cell.textLabel?.textColor = .white
+        cell.makeCornerRound(radius: CGFloat(Constraints.round))
+        cell.backgroundColor = .grayscales900
+        cell.textLabel?.textAlignment = .center
+        cell.selectionStyle = .gray
+        return cell
+    }
+    
+}
+
+// MARK: UITableViewDelegate
+extension StudentIdView: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let currentCell = tableView.cellForRow(at: indexPath),
+              let cellTitle = currentCell.textLabel?.text else {
+            return
+        }
+        
+        // 학번 문자열에서 숫자 부분 추출
+        let studentId = cellTitle.components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
+        guard let studentId = Int(studentId) else { return }
+        idDelegate?.didSelectStudentId(studentId)
+    }
+}

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/ViewController/BottomFriendProfileViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/ViewController/BottomFriendProfileViewController.swift
@@ -1,0 +1,47 @@
+//
+//  BottomFriendProfileViewController.swift
+//  YELLO-iOS
+//
+//  Created by 지희의 MAC on 2023/07/20.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class BottomFriendProfileViewController: BaseBottomViewController {
+    
+    // MARK: - Variables
+    // MARK: Component
+    let friendProfileView = FriendProfileView()
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.friendProfileView.layoutChange()
+    }
+    
+    // MARK: Layout Helpers
+    override func setViewHierarchy() {
+        super.setViewHierarchy()
+        friendProfileView.handleBottomSheetButtonDelegate = self
+    }
+    
+    override func setLayout() {
+        super.setLayout()
+        super.bottomSheetView.addSubview(friendProfileView)
+        
+        friendProfileView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+
+}
+
+// MARK: - extension
+// MARK: HandleBottomSheetButtonDelegate
+extension BottomFriendProfileViewController: HandleBottomSheetButtonDelegate {
+    func dismissView() {
+        self.dismiss(animated: true)
+    }
+}

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/ViewController/ProfileViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/ViewController/ProfileViewController.swift
@@ -16,6 +16,7 @@ final class ProfileViewController: BaseViewController {
     // MARK: Component
     private let profileView = ProfileView()
     let friendProfileViewController = FriendProfileViewController()
+    let bottomSheetViewController = BottomFriendProfileViewController()
     
     var isFinishPaging = false
     var isLoadingData = false
@@ -41,6 +42,7 @@ final class ProfileViewController: BaseViewController {
         profileView.navigationBarView.delegate = self
         profileView.handleFriendCellDelegate = self
         friendProfileViewController.friendProfileView.handleDeleteFriendButtonDelegate = self
+        bottomSheetViewController.friendProfileView.handleDeleteFriendButtonDelegate = self
     }
     
     override func setLayout() {
@@ -68,13 +70,21 @@ extension ProfileViewController: HandleFriendCellDelegate {
     func presentModal(index: Int) {
         profileView.indexNumber = index
         friendProfileViewController.friendProfileView.configureMyProfileFriendDetailCell(profileView.myProfileFriendModelDummy[index])
+        bottomSheetViewController.friendProfileView.configureMyProfileFriendDetailCell(profileView.myProfileFriendModelDummy[index])
+        
         let nav = UINavigationController(rootViewController: friendProfileViewController)
     
-        if let sheet = nav.sheetPresentationController {
-            sheet.detents = [.medium()]
-            sheet.prefersGrabberVisible = true
+        if #available(iOS 15.0, *) {
+            if let sheet = nav.sheetPresentationController {
+                sheet.detents = [.medium()]
+                sheet.prefersGrabberVisible = true
+                present(nav, animated: true, completion: nil)
+            }
+        } else {
+            bottomSheetViewController.modalPresentationStyle = .overFullScreen
+            present(bottomSheetViewController, animated: false)
         }
-        present(nav, animated: true, completion: nil)
+        
     }
 }
 
@@ -83,6 +93,7 @@ extension ProfileViewController: HandleDeleteFriendButtonDelegate {
         profileView.showToast(message: profileView.myProfileFriendModelDummy[profileView.indexNumber].name + StringLiterals.Profile.Friend.toastMessage)
         
         friendProfileViewController.friendProfileView.profileDeleteFriend(id: profileView.myProfileFriendModelDummy[profileView.indexNumber].userId)
+        bottomSheetViewController.friendProfileView.profileDeleteFriend(id: profileView.myProfileFriendModelDummy[profileView.indexNumber].userId)
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
             self.profileView.myProfileFriendModelDummy.remove(at: self.profileView.indexNumber)


### PR DESCRIPTION
## ⛏ 작업 내용
- iOS 14에서 네비게이션바 커스텀이 되지 않고 바텀 시트를 지원하지 않아서 기기대응을 했습니다. 


## 📌 PR Point!
- iOS 15 이하의 기기에는 다른 처리를 하도록 분기 처리를 했습니다.
- 바텀 시트를 커스텀 뷰로 만들어서 제작했습니다. 


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 온보딩 네비게이션바 커스텀 안됨 | ![Simulator Screenshot - iPhone6s - 2023-07-20 at 20 46 47](https://github.com/team-yello/YELLO-iOS/assets/68178395/58d5b2a7-7178-40bc-8c10-8a3b329f16c7) |
| 바텀시트 커스텀| ![Simulator Screenshot - iPhone6s - 2023-07-20 at 20 52 40](https://github.com/team-yello/YELLO-iOS/assets/68178395/6c7e762a-3346-474e-9e27-e47925b9366a)|


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #101 
