### PR TITLE
Fix [#107] 글자길이에 맞게 이름,키워드 BackgroundView 대응

### DIFF
--- a/YELLO-iOS/YELLO-iOS/Presentation/Voting/Voting/VotingViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Voting/Voting/VotingViewController.swift
@@ -23,7 +23,7 @@ final class VotingViewController: BaseViewController {
   
     private let nameStackView = UIStackView()
     let nameHead = UILabel()
-    let nameMiddleBackground = UIView(frame: CGRect(x: 0, y: 0, width: 86.adjusted, height: 34.adjusted))
+    var nameMiddleBackground = UIView(frame: CGRect(x: 0, y: 0, width: 70.adjusted, height: 34.adjusted))
 
     let nameMiddleText = UILabel()
     let nameFoot = UILabel()
@@ -35,7 +35,7 @@ final class VotingViewController: BaseViewController {
     
     private let keywordStackView = UIStackView()
     let keywordHead = UILabel()
-    let keywordMiddleBackground = UIView(frame: CGRect(x: 0, y: 0, width: 150.adjusted, height: 34.adjusted))
+    var keywordMiddleBackground = UIView(frame: CGRect(x: 0, y: 0, width: 150.adjusted, height: 34.adjusted))
     let keywordMiddleText = UILabel()
     let keywordFoot = UILabel()
     
@@ -123,13 +123,56 @@ final class VotingViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        let maxNameLength = votingList[VotingViewController.pushCount]?.friendList.compactMap { $0.components(separatedBy: "\n").first?.count }.max() ?? 0
+        let nameLength = (maxNameLength * 14).adjusted + 28.adjusted
+        
+        let maxKeywordLength = votingList[VotingViewController.pushCount]?.keywordList.compactMap { $0.count }.max() ?? 0
+        let keywordLength = (maxKeywordLength * 14).adjusted + 28.adjusted
+        
+        nameMiddleBackground = UIView(frame: CGRect(x: 0, y: 0, width: nameLength, height: 34.adjusted))
+        keywordMiddleBackground = UIView(frame: CGRect(x: 0, y: 0, width: keywordLength, height: 34.adjusted))
+        
+        nameMiddleBackground.do {
+            $0.backgroundColor = .grayscales900
+            $0.layer.cornerRadius = 8
+            $0.addDottedBorder()
+        }
+        
+        keywordMiddleBackground.do {
+            $0.backgroundColor = .grayscales900
+            $0.layer.cornerRadius = 8
+            $0.addDottedBorder()
+        }
+        
+        nameStackView.addArrangedSubviews(nameHead, nameMiddleBackground, nameFoot)
+        keywordStackView.addArrangedSubviews(keywordHead, keywordMiddleBackground, keywordFoot)
+        
+        nameMiddleBackground.snp.makeConstraints {
+            $0.width.equalTo(nameLength)
+            $0.height.equalTo(34.adjusted)
+        }
+        
+        nameMiddleText.snp.makeConstraints {
+            $0.width.equalTo(nameLength)
+            $0.height.equalTo(30.adjusted)
+        }
+        
+        keywordMiddleBackground.snp.makeConstraints {
+            $0.width.equalTo(keywordLength)
+            $0.height.equalTo(34.adjusted)
+        }
+        keywordMiddleText.snp.makeConstraints {
+            $0.width.equalTo(keywordLength)
+            $0.height.equalTo(30.adjusted)
+        }
         
         if VotingViewController.pushCount == 0 {
             Color.shared.startIndex = Int.random(in: 0...11)
             Color.shared.selectedTopColors = selectTopColors(startIndex: Color.shared.startIndex)
             Color.shared.selectedBottomColors = selectBottomColors(startIndex: Color.shared.startIndex)
         }
-
+        
         navigationController?.delegate = self
     }
     
@@ -206,12 +249,6 @@ final class VotingViewController: BaseViewController {
             $0.font = .uiLarge
         }
         
-        keywordMiddleBackground.do {
-            $0.backgroundColor = .grayscales900
-            $0.layer.cornerRadius = 8
-            $0.addDottedBorder()
-        }
-        
         keywordMiddleText.do {
             $0.textColor = .black
             $0.font = .uiBodyLarge
@@ -265,37 +302,14 @@ final class VotingViewController: BaseViewController {
         
         originView.questionBackground.addSubviews(nameStackView, keywordStackView)
         
-        nameStackView.addArrangedSubviews(nameHead, nameMiddleBackground, nameFoot)
-        keywordStackView.addArrangedSubviews(keywordHead, keywordMiddleBackground, keywordFoot)
-        
         nameStackView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(36.adjusted)
             $0.centerX.equalToSuperview()
         }
         
-        nameMiddleBackground.snp.makeConstraints {
-            $0.width.equalTo(86.adjusted)
-            $0.height.equalTo(34.adjusted)
-        }
-        
-        nameMiddleText.snp.makeConstraints {
-            $0.width.equalTo(82.adjusted)
-            $0.height.equalTo(30.adjusted)
-        }
-        
         keywordStackView.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(36.adjusted)
             $0.centerX.equalToSuperview()
-        }
-        
-        keywordMiddleBackground.snp.makeConstraints {
-            $0.width.equalTo(150.adjusted)
-            $0.height.equalTo(34.adjusted)
-        }
-        
-        keywordMiddleText.snp.makeConstraints {
-            $0.width.equalTo(144.adjusted)
-            $0.height.equalTo(30.adjusted)
         }
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Voting/Voting/VotingViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Voting/Voting/VotingViewController.swift
@@ -124,6 +124,19 @@ final class VotingViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        setBackground()
+        navigationController?.delegate = self
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+    
+        tabBarController?.tabBar.isHidden = true
+    }
+    
+    // MARK: - Private Function
+    
+    private func setBackground() {
         let maxNameLength = votingList[VotingViewController.pushCount]?.friendList.compactMap { $0.components(separatedBy: "\n").first?.count }.max() ?? 0
         let nameLength = (maxNameLength * 14).adjusted + 28.adjusted
         
@@ -172,14 +185,6 @@ final class VotingViewController: BaseViewController {
             Color.shared.selectedTopColors = selectTopColors(startIndex: Color.shared.startIndex)
             Color.shared.selectedBottomColors = selectBottomColors(startIndex: Color.shared.startIndex)
         }
-        
-        navigationController?.delegate = self
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-    
-        tabBarController?.tabBar.isHidden = true
     }
     
     // MARK: - Style

--- a/YELLO-iOS/YELLO-iOS/Presentation/Voting/VotingStart/VotingStartViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Voting/VotingStart/VotingStartViewController.swift
@@ -149,7 +149,7 @@ extension VotingStartViewController {
                     var friends = [String]()
                     var friendsID = [Int]()
                     for i in 0...3 {
-                        friends.append(data.friendList[i].name + "\n" + data.friendList[i].yelloId)
+                        friends.append(data.friendList[i].name + "\n@" + data.friendList[i].yelloId)
                         friendsID.append(data.friendList[i].id)
                     }
                     var keywords = [String]()


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 투표화면 이름 BackGroundView 글자길이에 맞게 크기 대응
- 투표화면 키워드 BackGroundView 글자길이에 맞게 크기 대응
<!--
```
작성한 코드가 있다면 여기에 주석을 제거하고 적어주세요!
```
-->


## 📌 PR Point!
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 이제 이름, 키워드에 따라 BackgroundView의 길이가 잘 변합니당 ‼️


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |

https://github.com/team-yello/YELLO-iOS/assets/97782228/bad41754-aded-45bc-88ba-e71c7313173c


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #107 
