### PR TITLE
Feat [#119] 애플로그인 버튼 연결 추가 및 로그인 연동

### DIFF
--- a/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
+++ b/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
@@ -298,6 +298,7 @@
 		36871C7A2A664C69001CA514 /* JoinedFriendsResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinedFriendsResponseDTO.swift; sourceTree = "<group>"; };
 		36871C7C2A664CD8001CA514 /* JoinedFriendsRequestQueryDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinedFriendsRequestQueryDTO.swift; sourceTree = "<group>"; };
 		369BF9672A6AFC640091CB85 /* TokenRefreshResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenRefreshResponseDTO.swift; sourceTree = "<group>"; };
+		369BF96B2A6E67DD0091CB85 /* YELLO-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "YELLO-iOS.entitlements"; sourceTree = "<group>"; };
 		36AD44192A6812420087D7E0 /* MyRequestInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyRequestInterceptor.swift; sourceTree = "<group>"; };
 		36B234952A61466A007933E4 /* YelloHelperLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YelloHelperLabel.swift; sourceTree = "<group>"; };
 		36B234972A619853007933E4 /* onboarding_end.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = onboarding_end.json; sourceTree = "<group>"; };
@@ -1030,6 +1031,7 @@
 		C3A799952A49490A00D3EFD8 /* YELLO-iOS */ = {
 			isa = PBXGroup;
 			children = (
+				369BF96B2A6E67DD0091CB85 /* YELLO-iOS.entitlements */,
 				C3A799C72A494B7800D3EFD8 /* Storyboard */,
 				C3A799B92A494A6800D3EFD8 /* Application */,
 				C3A799BA2A494A7700D3EFD8 /* Global */,
@@ -1830,6 +1832,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				BASE_URL = "$(BASE_URL)";
+				CODE_SIGN_ENTITLEMENTS = "YELLO-iOS/YELLO-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1866,6 +1869,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				BASE_URL = "$(BASE_URL)";
+				CODE_SIGN_ENTITLEMENTS = "YELLO-iOS/YELLO-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoLoginViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoLoginViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import KakaoSDKUser
 import AuthenticationServices
 
-class KakaoLoginViewController: BaseViewController {
+final class KakaoLoginViewController: BaseViewController {
     
     let baseView = KakaoLoginView()
     override func loadView() {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/KakaoLoginView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/KakaoLoginView.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import AuthenticationServices
 
 class KakaoLoginView: BaseView {
 
@@ -13,8 +14,10 @@ class KakaoLoginView: BaseView {
     let subTitleLabel = UILabel()
     let imageView = UIImageView()
     let kakaoButton = UIButton()
+    let authorizationButton = ASAuthorizationAppleIDButton(type: .signIn, style: .white)
     
     let stackView = UIStackView()
+    let loginStackView = UIStackView()
     
     override func setStyle() {
         
@@ -44,9 +47,16 @@ class KakaoLoginView: BaseView {
             $0.alignment = .center
         }
         
+        loginStackView.do {
+            $0.addArrangedSubviews(kakaoButton, authorizationButton)
+            $0.axis = .vertical
+            $0.spacing = 10
+        }
+        
         kakaoButton.do {
             $0.setImage(ImageLiterals.OnBoarding.btnKakaoLogin, for: .normal)
         }
+        
     }
     
     override func setLayout() {
@@ -54,7 +64,7 @@ class KakaoLoginView: BaseView {
         self.addSubviews(titleLabel,
                          subTitleLabel,
                          imageView,
-                         kakaoButton)
+                         loginStackView)
         
         titleLabel.snp.makeConstraints {
             $0.bottom.equalTo(subTitleLabel.snp.top).offset(-8)
@@ -70,9 +80,18 @@ class KakaoLoginView: BaseView {
             $0.center.equalToSuperview()
         }
         
-        kakaoButton.snp.makeConstraints {
+        authorizationButton.snp.makeConstraints {
+            $0.height.equalTo(48)
+        }
+        
+        loginStackView.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(91)
             $0.leading.trailing.equalToSuperview().inset(16)
         }
     }
+    func setupProviderLoginView() {
+     
+     
+    }
+    
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/KakaoLoginView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/KakaoLoginView.swift
@@ -8,7 +8,7 @@
 import UIKit
 import AuthenticationServices
 
-class KakaoLoginView: BaseView {
+final class KakaoLoginView: BaseView {
 
     let titleLabel = UILabel()
     let subTitleLabel = UILabel()

--- a/YELLO-iOS/YELLO-iOS/Presentation/Recommending/View/KakaoFriendView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Recommending/View/KakaoFriendView.swift
@@ -207,6 +207,7 @@ extension KakaoFriendView {
             }
         }
     }
+    
     func kakaoFriends(){
         TalkApi.shared.friends {(friends, error) in
             if let error = error {

--- a/YELLO-iOS/YELLO-iOS/YELLO-iOS.entitlements
+++ b/YELLO-iOS/YELLO-iOS/YELLO-iOS.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## ⛏ 작업 내용
온보딩의 로그인 화면에 애플 로그인을 추가했습니다. 아직 서버에서 애플로그인에 대한 처리를 이뤄지지 않으므로 로그인만 가능하게 해두었습니다. 

## 📌 PR Point!
H.I.G에서 제공하는 로그인 버튼 가이드라인을 그대로 사용하다보니 카카오 로그인과의 통일성이 조금 부족한 것 같지만 원래 피그마의 디자인도 아래와 같기 때문에 그냥 진행했는데 괜찮을까요?!

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 로그인 화면 |![Simulator Screen Recording - iPhone 13 mini - 2023-07-24 at 17 24 58](https://github.com/team-yello/YELLO-iOS/assets/68178395/559b36f3-391b-452f-90bf-4941d39d138b) |
| 로그인 확인 |<img width="284" alt="스크린샷 2023-07-24 오후 5 25 03" src="https://github.com/team-yello/YELLO-iOS/assets/68178395/a2046c35-c3d0-4e1d-9011-743104d8daa8"> |


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #119 
