### PR TITLE
[Fix] ID 글자수 제한 

### DIFF
--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/UserInfoViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/UserInfoViewController.swift
@@ -16,6 +16,8 @@ class UserInfoViewController: OnboardingBaseViewController {
     lazy var isIdDuplicate = false
     var isCheckingDuplicate = false
     
+    let maxLength = 20
+    
     // MARK: Component
     private let baseView = UserInfoView()
     
@@ -58,8 +60,13 @@ class UserInfoViewController: OnboardingBaseViewController {
     
     // MARK: Custom Function
     func setDelegate() {
+        NotificationCenter.default.addObserver(self,
+                                                       selector: #selector(textDidChange(_:)),
+                                                       name: UITextField.textDidChangeNotification,
+                                               object: baseView.idTextField.textField)
         baseView.idTextField.textField.delegate = self
         baseView.nameTextField.textField.delegate = self
+        
     }
     
     // MARK: Custom Function
@@ -137,6 +144,24 @@ class UserInfoViewController: OnboardingBaseViewController {
         User.shared.name = name
         User.shared.yelloId = id
     }
+    
+    @objc private func textDidChange(_ notification: Notification) {
+            if let textField = notification.object as? UITextField {
+                if let text = textField.text {
+                    
+                    if text.count > maxLength {
+                        textField.resignFirstResponder()
+                    }
+                    
+                    // 초과되는 텍스트 제거
+                    if text.count >= maxLength {
+                        let index = text.index(text.startIndex, offsetBy: maxLength)
+                        let newString = text[text.startIndex..<index]
+                        textField.text = String(newString)
+                    }
+                }
+            }
+        }
 
 }
 
@@ -154,6 +179,17 @@ extension UserInfoViewController: UITextFieldDelegate {
             idTextField.setButtonState(state: .cancel)
         }
     }
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+            guard let text = textField.text else {return false}
+            
+            // 최대 글자수 이상을 입력한 이후에는 중간에 다른 글자를 추가할 수 없게끔 작동
+            if text.count >= maxLength && range.length == 0 && range.location < maxLength {
+                return false
+            }
+            
+            return true
+        }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.endEditing(true)


### PR DESCRIPTION
## ⛏ 작업 내용
- id입력 텍스트필드에 글자수 제한을 해두었습니다. 
- 제한된 글자수 (20자)가 넘어가면 더 이상 입력이 되지 않고 자동으로 키보드를 내립니다. 


## 📌 PR Point!
- `UITextFieldDelegate`를 이용하여 글자수 제한이 넘어가면 더 이상 입력이 되지 않도록 제한했습니다. 
``` swift 
 func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
            guard let text = textField.text else {return false}
            
            // 최대 글자수 이상을 입력한 이후에는 중간에 다른 글자를 추가할 수 없게끔 작동
            if text.count >= maxLength && range.length == 0 && range.location < maxLength {
                return false
            }
            
            return true
        }
```
- `Notificationcenter`를 이용하여 20자 이상의 글자는 제거되고 글자수 제한이 넘으면 자동으로 키보드를 내리도록 했습니다. 
``` swift
   if text.count > maxLength {
       textField.resignFirstResponder()
   }
```

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| ID 작성 |![Simulator Screen Recording - iPhone 13 mini - 2023-07-31 at 00 23 17](https://github.com/team-yello/YELLO-iOS/assets/68178395/2a68e9ff-f80d-4a0c-b3f3-785d436c8537) |



### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #131 
