### PR TITLE
Feat [#137] 로컬 푸시 알림 구현

### DIFF
--- a/YELLO-iOS/YELLO-iOS/Application/AppDelegate.swift
+++ b/YELLO-iOS/YELLO-iOS/Application/AppDelegate.swift
@@ -15,6 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         KakaoSDK.initSDK(appKey: Config.kakaoAppKey)
+        UNUserNotificationCenter.current().delegate = self
         return true
     }
 
@@ -40,5 +41,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return false
     }
     
+}
+
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.alert, .badge, .sound])
+    }
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler completionHandler: @escaping () -> Void) {
+
+        // deep link처리 시 아래 url값 가지고 처리
+        let url = response.notification.request.content.userInfo
+
+        completionHandler()
+    }
 }
 

--- a/YELLO-iOS/YELLO-iOS/Presentation/Voting/VotingStart/VotingStartViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Voting/VotingStart/VotingStartViewController.swift
@@ -16,6 +16,7 @@ final class VotingStartViewController: BaseViewController {
     let originView = BaseVotingETCView()
     private var animationView = LottieAnimationView()
     var myPoint = 0
+    let userNotiCenter = UNUserNotificationCenter.current()
     
     override func loadView() {
         self.view = originView
@@ -23,6 +24,8 @@ final class VotingStartViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        requestAuthNoti()
 
         originView.yellowButton.isEnabled = false
         getVotingAvailable()
@@ -185,4 +188,14 @@ extension VotingStartViewController {
         }
     }
     
+    // 사용자에게 알림 권한 요청
+    func requestAuthNoti() {
+        let notiAuthOptions = UNAuthorizationOptions(arrayLiteral: [.alert, .badge, .sound])
+        userNotiCenter.requestAuthorization(options: notiAuthOptions) { (success, error) in
+            if let error = error {
+                print(#function, error)
+            }
+        }
+    }
+
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Voting/VotingTimer/VotingTimerViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Voting/VotingTimer/VotingTimerViewController.swift
@@ -26,7 +26,7 @@ final class VotingTimerViewController: BaseViewController {
                 let viewController = VotingStartViewController()
                 viewController.myPoint = myPoint
                 self.navigationController?.pushViewController(viewController, animated: false)
-                requestSendNoti(seconds: 3.3)
+                requestSendNoti(seconds: 0.3)
             }
         }
     }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Voting/VotingTimer/VotingTimerViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Voting/VotingTimer/VotingTimerViewController.swift
@@ -15,6 +15,7 @@ final class VotingTimerViewController: BaseViewController {
     var timer: Timer?
     
     var myPoint = 0
+    let userNotiCenter = UNUserNotificationCenter.current()
     
     var remainingSeconds: TimeInterval? {
         didSet {
@@ -25,6 +26,7 @@ final class VotingTimerViewController: BaseViewController {
                 let viewController = VotingStartViewController()
                 viewController.myPoint = myPoint
                 self.navigationController?.pushViewController(viewController, animated: false)
+                requestSendNoti(seconds: 3.3)
             }
         }
     }
@@ -269,5 +271,26 @@ extension VotingTimerViewController {
                 return
             }
         }
+    }
+    // 알림 전송
+    func requestSendNoti(seconds: Double) {
+        let notiContent = UNMutableNotificationContent()
+        notiContent.title = "친구에게 쪽지 보내고 포인트 받기"
+        notiContent.body = "대기시간이 다 지났어요. 친구들에게 투표해봐요!"
+        notiContent.userInfo = ["targetScene": "splash"] // 푸시 받을때 오는 데이터
+        
+        // 알림이 trigger되는 시간 설정
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: seconds, repeats: false)
+        
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: notiContent,
+            trigger: trigger
+        )
+        
+        userNotiCenter.add(request) { (error) in
+            print(#function, error)
+        }
+        
     }
 }


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
⬇️ 로컬 푸시 알림 구현
- AppDelegate
https://github.com/team-yello/YELLO-iOS/blob/8f80169ee37dd0277f6bf8f9aa23966c471dda41/YELLO-iOS/YELLO-iOS/Application/AppDelegate.swift#L16-L20
https://github.com/team-yello/YELLO-iOS/blob/8f80169ee37dd0277f6bf8f9aa23966c471dda41/YELLO-iOS/YELLO-iOS/Application/AppDelegate.swift#L46-L62

<!--
```
작성한 코드가 있다면 여기에 주석을 제거하고 적어주세요!
```
-->


## 📌 PR Point!
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 알림받기 뷰가 구현되지 않아서 우선 VotingStartViewController에 들어왔을 때 알림 권한 요청을 하도록 구현했습니다.
https://github.com/team-yello/YELLO-iOS/blob/8f80169ee37dd0277f6bf8f9aa23966c471dda41/YELLO-iOS/YELLO-iOS/Presentation/Voting/VotingStart/VotingStartViewController.swift#L192-L199

- 타이머 시간이 다 되면 푸시알림이 옵니다.
https://github.com/team-yello/YELLO-iOS/blob/8f80169ee37dd0277f6bf8f9aa23966c471dda41/YELLO-iOS/YELLO-iOS/Presentation/Voting/VotingTimer/VotingTimerViewController.swift#L25-L30


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 알림 권한 요청 | ![Simulator Screen Recording - YELL O_TEST - 2023-08-01 at 11 04 26](https://github.com/team-yello/YELLO-iOS/assets/97782228/9293099f-2743-4042-86ee-e5dc740b6630) |
| 타이머 완료 | ![Simulator Screen Recording - YELL O_TEST - 2023-08-01 at 11 45 25](https://github.com/team-yello/YELLO-iOS/assets/97782228/4530bcfc-cdf3-44f1-9162-268a73a62f57) |


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #137 
