### PR TITLE
Feat [#205] 내 옐로 구독, 열람권 여부에 따른 UI 변경

### DIFF
--- a/YELLO-iOS/YELLO-iOS/Network/MyYello/DTO/Response/MyYelloDetailResponseDTO.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/MyYello/DTO/Response/MyYelloDetailResponseDTO.swift
@@ -11,10 +11,10 @@ struct MyYelloDetailResponseDTO: Codable {
     let nameHint: Int
     let colorIndex: Int
     let currentPoint: Int
+    let ticketCount: Int
     let isAnswerRevealed: Bool
+    let isSubscribe: Bool
     let senderName: String
     let senderGender: String
     let vote: Vote
-    let ticketCount: Int
-    let isSubscribe: Bool
 }

--- a/YELLO-iOS/YELLO-iOS/Network/MyYello/DTO/Response/MyYelloResponseDTO.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/MyYello/DTO/Response/MyYelloResponseDTO.swift
@@ -10,6 +10,7 @@ import Foundation
 // MARK: - DataClass
 struct MyYelloResponseDTO: Codable {
     let totalCount: Int
+    let ticketCount: Int
     let votes: [Yello]
 }
 

--- a/YELLO-iOS/YELLO-iOS/Presentation/Inviting/InvitingView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Inviting/InvitingView.swift
@@ -177,8 +177,10 @@ extension InvitingView {
     
     @objc
     func kakaoButtonClicked() {
-//        let templateId = 95890
-        let templateId = 96906
+        // 실 서버
+        let templateId = 95890
+        // 개발 서버
+//        let templateId = 96906
         guard let filteredString = self.recommenderID.text else { return }
         let recommenderID = String(filteredString.dropFirst())
         UIPasteboard.general.string = recommenderID

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Button/MyYelloButton.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Button/MyYelloButton.swift
@@ -21,13 +21,11 @@ final class MyYelloButton: UIButton {
     private enum Color {
         static var gradientColors = [
             UIColor.white,
-//            UIColor.white.withAlphaComponent(0.9),
             UIColor.white.withAlphaComponent(0.6),
             UIColor.white.withAlphaComponent(0.3),
             UIColor.white.withAlphaComponent(0.0),
             UIColor.white.withAlphaComponent(0.3),
             UIColor.white.withAlphaComponent(0.6),
-//            UIColor.white.withAlphaComponent(0.9),
             UIColor.white
         ]
     }
@@ -97,7 +95,6 @@ final class MyYelloButton: UIButton {
         self.layer.cornerCurve = .continuous
 
         backgroundView.do {
-//            $0.frame = CGRect(x: 0, y: 0, width: 343.adjusted, height: 62.adjusted)
             $0.backgroundColor = .clear
             $0.makeCornerRound(radius: Constants.cornerRadius)
             $0.layer.cornerCurve = .continuous
@@ -168,9 +165,6 @@ final class MyYelloButton: UIButton {
         
         backgroundView.snp.makeConstraints {
             $0.edges.equalToSuperview()
-//            $0.centerX.equalToSuperview().offset(-1.adjustedHeight)
-//            $0.width.equalToSuperview()
-//            $0.height.equalTo(62.adjusted)
         }
         
         titleStackView.snp.makeConstraints {

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloDefaultTableViewCell.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloDefaultTableViewCell.swift
@@ -45,13 +45,6 @@ final class MyYelloDefaultTableViewCell: UITableViewCell {
         contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 0, left: 0, bottom: 8.adjustedHeight, right: 0))
     }
     
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        genderImageView.image = nil
-        titleLabel.text = nil
-        timeLabel.text = nil
-    }
-    
     // MARK: Layout Helpers
     private func setUI() {
         setStyle()
@@ -76,7 +69,6 @@ final class MyYelloDefaultTableViewCell: UITableViewCell {
         newView.do {
             $0.backgroundColor = .semanticStatusYellow500
             $0.makeCornerRound(radius: 2.adjustedHeight)
-
         }
         
         timeLabel.do {

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloKeywordTableViewCell.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloKeywordTableViewCell.swift
@@ -159,9 +159,20 @@ final class MyYelloKeywordTableViewCell: UITableViewCell {
             keywordLabel.snp.makeConstraints {
                 $0.leading.equalToSuperview()
             }
+        } else {
+            keywordHeadLabel.text = model.vote.keywordHead
+            
+            keywordHeadLabel.snp.remakeConstraints {
+                $0.bottom.equalToSuperview()
+                $0.leading.equalToSuperview()
+            }
+            
+            keywordLabel.snp.remakeConstraints {
+                $0.bottom.equalTo(keywordHeadLabel)
+                $0.leading.equalTo(keywordHeadLabel.snp.trailing).inset(-2.adjustedWidth)
+            }
         }
         
-        keywordHeadLabel.text = model.vote.keywordHead
         keywordLabel.text = model.vote.keyword
         keywordFootLabel.text = model.vote.keywordFoot ?? ""
         timeLabel.text = model.createdAt

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloKeywordTableViewCell.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloKeywordTableViewCell.swift
@@ -43,16 +43,6 @@ final class MyYelloKeywordTableViewCell: UITableViewCell {
         contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 0, left: 0, bottom: 8.adjustedHeight, right: 0))
     }
     
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        genderImageView.image = nil
-        nameLabel.text = nil
-        keywordHeadLabel.text = nil
-        keywordLabel.text = nil
-        keywordFootLabel.text = nil
-        timeLabel.text = nil
-    }
-    
     private func setUI() {
         setStyle()
         setLayout()

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloNameTableViewCell.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloNameTableViewCell.swift
@@ -188,9 +188,19 @@ final class MyYelloNameTableViewCell: UITableViewCell {
             keywordLabel.snp.makeConstraints {
                 $0.leading.equalToSuperview()
             }
+        } else {
+            keywordHeadLabel.text = model.vote.keywordHead
+            keywordHeadLabel.snp.remakeConstraints {
+                $0.bottom.equalToSuperview()
+                $0.leading.equalToSuperview()
+            }
+            
+            keywordLabel.snp.remakeConstraints {
+                $0.bottom.equalTo(keywordHeadLabel)
+                $0.leading.equalTo(keywordHeadLabel.snp.trailing).inset(-2.adjustedWidth)
+            }
         }
         
-        keywordHeadLabel.text = model.vote.keywordHead
         keywordLabel.text = model.vote.keyword
         keywordFootLabel.text = model.vote.keywordFoot ?? ""
         timeLabel.text = model.createdAt

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloNameTableViewCell.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloNameTableViewCell.swift
@@ -162,17 +162,6 @@ final class MyYelloNameTableViewCell: UITableViewCell {
         }
     }
     
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        genderImageView.image = nil
-        initialLabel.text = nil
-        nameLabel.text = nil
-        keywordHeadLabel.text = nil
-        keywordLabel.text = nil
-        keywordFootLabel.text = nil
-        timeLabel.text = nil
-    }
-    
     // MARK: Custom Function
     func configureNameCell(_ model: Yello) {
         if model.senderGender == "MALE" {
@@ -214,7 +203,7 @@ final class MyYelloNameTableViewCell: UITableViewCell {
             if let initial = getSecondInitial(model.senderName as NSString, index: 1) {
                 initialLabel.text = initial
             }
-        } else if model.nameHint == -3 {
+        } else if model.nameHint == -3 || model.nameHint == -2 {
             initialLabel.text = model.senderName
         }
     }

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloOnlyNameTableViewCell.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloOnlyNameTableViewCell.swift
@@ -41,13 +41,6 @@ final class MyYelloOnlyNameTableViewCell: UITableViewCell {
         contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 0, left: 0, bottom: 8.adjustedHeight, right: 0))
     }
     
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        genderImageView.image = nil
-        titleLabel.text = nil
-        timeLabel.text = nil
-    }
-    
     // MARK: Layout Helpers
     private func setUI() {
         setStyle()
@@ -65,8 +58,8 @@ final class MyYelloOnlyNameTableViewCell: UITableViewCell {
         
         nameStackView.do {
             $0.addArrangedSubviews(nameLabel, titleLabel)
-            $0.axis = .vertical
-            $0.spacing = 2.adjustedHeight
+            $0.axis = .horizontal
+            $0.spacing = 2.adjustedWidth
         }
         
         nameLabel.do {
@@ -76,7 +69,7 @@ final class MyYelloOnlyNameTableViewCell: UITableViewCell {
         }
         
         titleLabel.do {
-            $0.setTextWithLineHeight(text: StringLiterals.MyYello.List.nameTitle, lineHeight: 20.adjustedHeight)
+            $0.text = StringLiterals.MyYello.List.nameTitle
             $0.font = .uiBodySmall
             $0.textColor = .semanticGenderF300
         }
@@ -110,22 +103,22 @@ final class MyYelloOnlyNameTableViewCell: UITableViewCell {
     }
     
     // MARK: Custom Function
-    func configureDefaultCell(_ model: Yello) {
+    func configureOnlyNameCell(_ model: Yello) {
         
         if model.senderGender == "MALE" {
             contentView.backgroundColor = .semanticGenderM700
             genderImageView.image = ImageLiterals.MyYello.imgGenderMale
-            titleLabel.text = StringLiterals.MyYello.List.maleTitle
+            nameLabel.text = model.senderName
             nameLabel.textColor = .semanticGenderM300
             titleLabel.textColor = .semanticGenderM300
-            timeLabel.textColor = .semanticGenderM300
+            timeLabel.textColor = .semanticGenderM500
         } else {
             contentView.backgroundColor = .semanticGenderF700
             genderImageView.image = ImageLiterals.MyYello.imgGenderFemale
-            titleLabel.text = StringLiterals.MyYello.List.femaleTitle
+            nameLabel.text = model.senderName
             nameLabel.textColor = .semanticGenderF300
             titleLabel.textColor = .semanticGenderF300
-            timeLabel.textColor = .semanticGenderF300
+            timeLabel.textColor = .semanticGenderF500
         }
         
         timeLabel.text = model.createdAt

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/MyYelloDetailView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/MyYelloDetailView.swift
@@ -50,6 +50,9 @@ final class MyYelloDetailView: BaseView {
                 if isTicketUsed {
                     senderButton.setButtonState(state: .useTicket)
                 }
+                if nameIndex == -3 {
+                    senderButton.setButtonState(state: .noTicket)
+                }
             } else {
                 senderButton.setButtonState(state: .noTicket)
                 if isTicketUsed {
@@ -60,11 +63,14 @@ final class MyYelloDetailView: BaseView {
     }
     var isTicketUsed: Bool = false {
         didSet {
-            senderButton.setButtonState(state: .useTicket)
             if isKeywordUsed == true {
+                senderButton.setButtonState(state: .useTicket)
                 keywordButton.isHidden = true
                 senderButton.snp.makeConstraints {
                     $0.top.equalTo(instagramButton.snp.bottom).offset(77.adjustedHeight)
+                }
+                if self.nameIndex == -3 {
+                    senderButton.setButtonState(state: .noTicket)
                 }
             }
         }

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/MyYelloDetailView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/MyYelloDetailView.swift
@@ -46,6 +46,7 @@ final class MyYelloDetailView: BaseView {
         didSet {
             if haveTicket {
                 senderButton.setButtonState(state: .yesTicket)
+                senderButton.keyCountLabel.text = String(self.ticketCount)
                 if isTicketUsed {
                     senderButton.setButtonState(state: .useTicket)
                 }
@@ -135,7 +136,6 @@ final class MyYelloDetailView: BaseView {
         }
     }
     
-    var currentTicket: Int = 2
     var voteIdNumber: Int = 0
     var initialName: String = ""
     
@@ -358,7 +358,7 @@ extension MyYelloDetailView {
         guard let viewController = UIApplication.shared.keyWindow?.rootViewController else { return }
         useTicketView.removeFromSuperview()
         useTicketView = UseTicketView()
-        useTicketView.ticketLabel.text = String(self.currentTicket)
+        useTicketView.ticketLabel.text = String(self.ticketCount)
         useTicketView.frame = viewController.view.bounds
         useTicketView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         useTicketView.handleConfirmTicketButtonDelegate = self

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/MyYelloDetailView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/MyYelloDetailView.swift
@@ -495,7 +495,9 @@ extension MyYelloDetailView {
                 self.detailSenderView.senderLabel.text = initial
                 self.getFullNameView.hintLabel.text = initial
                 self.getFullNameView.ticketLabel.text = String(self.ticketCount - 1)
-                
+                self.isTicketUsed = true
+                self.senderButton.setButtonState(state: .useTicket)
+
                 MyYelloListView.myYelloModelDummy[self.indexNumber].nameHint = -2
                 
                 dump(data)
@@ -559,6 +561,5 @@ extension MyYelloDetailView: HandleConfirmTicketButtonDelegate {
     func confirmTicketButtonTapped() {
         showGetFullNameAlert()
         myYelloDetailFullName(voteId: voteIdNumber)
-        isTicketUsed.toggle()
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/MyYelloDetailView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/MyYelloDetailView.swift
@@ -46,8 +46,14 @@ final class MyYelloDetailView: BaseView {
         didSet {
             if haveTicket {
                 senderButton.setButtonState(state: .yesTicket)
+                if isTicketUsed {
+                    senderButton.setButtonState(state: .useTicket)
+                }
             } else {
                 senderButton.setButtonState(state: .noTicket)
+                if isTicketUsed {
+                    senderButton.setButtonState(state: .useTicket)
+                }
             }
         }
     }

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/UseTicketView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/UseTicketView.swift
@@ -82,7 +82,7 @@ final class UseTicketView: BaseView {
         }
         
         ticketLabel.do {
-            $0.text = "2"
+            $0.text = " "
             $0.textColor = .white
             $0.font = .uiKeywordBold
             $0.textAlignment = .right

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/ViewController/MyYelloDetailViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/ViewController/MyYelloDetailViewController.swift
@@ -194,6 +194,10 @@ extension MyYelloDetailViewController {
                     self.myYelloDetailView.senderButton.snp.makeConstraints {
                         $0.top.equalTo(self.myYelloDetailView.instagramButton.snp.bottom).offset(77.adjustedHeight)
                     }
+                } else if data.nameHint == -2 {
+                    self.myYelloDetailView.isTicketUsed = true
+                    self.myYelloDetailView.detailSenderView.senderLabel.text = data.senderName
+                    self.myYelloDetailView.isKeywordUsed = data.isAnswerRevealed
                 }
                 
                 // DTO 추가
@@ -274,7 +278,6 @@ extension MyYelloDetailViewController: HandleInstagramButtonDelegate {
         } else if !myYelloDetailView.isKeywordUsed && !myYelloDetailView.isSenderUsed {
             Amplitude.instance().logEvent("click_instagram", withEventProperties: ["insta_view": "message"])
         }
-        
         
         if let storyShareURL = URL(string: "instagram-stories://share?source_application=" + Config.metaAppID) {
             

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/ViewController/MyYelloDetailViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/ViewController/MyYelloDetailViewController.swift
@@ -156,6 +156,11 @@ extension MyYelloDetailViewController {
                 self.myYelloDetailView.senderButton.isHidden = false
                 self.setBackgroundView()
                 
+                // DTO 추가
+                if data.isSubscribe {
+                    self.myYelloDetailView.isPlus = true
+                }
+                
                 if data.senderGender == "MALE" {
                     self.myYelloDetailView.genderLabel.text = StringLiterals.MyYello.Detail.male
                 } else {
@@ -188,21 +193,16 @@ extension MyYelloDetailViewController {
                     self.myYelloDetailView.isSenderUsed = true
                     self.myYelloDetailView.detailSenderView.senderLabel.text = data.senderName
                     self.myYelloDetailView.isKeywordUsed = true
-                    self.myYelloDetailView.senderButton.setButtonState(state: .noTicket)
                     self.myYelloDetailView.keywordButton.isHidden = true
                     self.myYelloDetailView.haveTicket = false
                     self.myYelloDetailView.senderButton.snp.makeConstraints {
                         $0.top.equalTo(self.myYelloDetailView.instagramButton.snp.bottom).offset(77.adjustedHeight)
                     }
+                    self.myYelloDetailView.senderButton.setButtonState(state: .noTicket)
                 } else if data.nameHint == -2 {
                     self.myYelloDetailView.isTicketUsed = true
                     self.myYelloDetailView.detailSenderView.senderLabel.text = data.senderName
                     self.myYelloDetailView.isKeywordUsed = data.isAnswerRevealed
-                }
-                
-                // DTO 추가
-                if data.isSubscribe {
-                    self.myYelloDetailView.isPlus = true
                 }
                 
                 self.myYelloDetailView.ticketCount = data.ticketCount

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/ViewController/MyYelloDetailViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/ViewController/MyYelloDetailViewController.swift
@@ -100,7 +100,12 @@ extension MyYelloDetailViewController {
     
     @objc private func senderButtonTapped() {
         if myYelloDetailView.haveTicket {
-            myYelloDetailView.showUseTicketAlert()
+            if myYelloDetailView.nameIndex == -3 {
+                let paymentPlusViewController = PaymentPlusViewController()
+                navigationController?.pushViewController(paymentPlusViewController, animated: true)
+            } else {
+                myYelloDetailView.showUseTicketAlert()
+            }
         } else {
             let paymentPlusViewController = PaymentPlusViewController()
             if myYelloDetailView.isKeywordUsed && !(myYelloDetailView.isPlus) && !(myYelloDetailView.isSenderUsed) {
@@ -178,6 +183,7 @@ extension MyYelloDetailViewController {
                 self.myYelloDetailView.detailKeywordView.keywordFootLabel.text = (data.vote.keywordFoot ?? "")
                 
                 self.myYelloDetailView.isKeywordUsed = data.isAnswerRevealed
+                self.myYelloDetailView.nameIndex = data.nameHint
                 
                 if data.nameHint == 0 {
                     self.myYelloDetailView.isSenderUsed = true
@@ -194,11 +200,9 @@ extension MyYelloDetailViewController {
                     self.myYelloDetailView.detailSenderView.senderLabel.text = data.senderName
                     self.myYelloDetailView.isKeywordUsed = true
                     self.myYelloDetailView.keywordButton.isHidden = true
-                    self.myYelloDetailView.haveTicket = false
                     self.myYelloDetailView.senderButton.snp.makeConstraints {
                         $0.top.equalTo(self.myYelloDetailView.instagramButton.snp.bottom).offset(77.adjustedHeight)
                     }
-                    self.myYelloDetailView.senderButton.setButtonState(state: .noTicket)
                 } else if data.nameHint == -2 {
                     self.myYelloDetailView.isTicketUsed = true
                     self.myYelloDetailView.detailSenderView.senderLabel.text = data.senderName

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/View/MyYelloListView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/View/MyYelloListView.swift
@@ -162,20 +162,25 @@ extension MyYelloListView: UITableViewDataSource {
             cell.showShimmer()
             return cell
         } else {
-            if MyYelloListView.myYelloModelDummy[indexPath.row].isHintUsed == false || (MyYelloListView.myYelloModelDummy[indexPath.row].nameHint == -3 && MyYelloListView.myYelloModelDummy[indexPath.row].isRead == false) {
+            if (MyYelloListView.myYelloModelDummy[indexPath.row].nameHint == -1 && MyYelloListView.myYelloModelDummy[indexPath.row].isHintUsed == false) || (MyYelloListView.myYelloModelDummy[indexPath.row].nameHint == -3 && MyYelloListView.myYelloModelDummy[indexPath.row].isRead == false) {
                 guard let defaultCell = tableView.dequeueReusableCell(withIdentifier: MyYelloDefaultTableViewCell.identifier, for: indexPath) as? MyYelloDefaultTableViewCell else { return UITableViewCell() }
-                
                 defaultCell.configureDefaultCell(MyYelloListView.myYelloModelDummy[indexPath.row])
                 defaultCell.isRead = MyYelloListView.myYelloModelDummy[indexPath.row].isRead
                 defaultCell.newView.isHidden = defaultCell.isRead
                 defaultCell.selectionStyle = .none
                 return defaultCell
-            } else if MyYelloListView.myYelloModelDummy[indexPath.row].nameHint == -1 {
+            } else if MyYelloListView.myYelloModelDummy[indexPath.row].isHintUsed == true && MyYelloListView.myYelloModelDummy[indexPath.row].nameHint == -1 {
                 guard let keywordCell = tableView.dequeueReusableCell(withIdentifier: MyYelloKeywordTableViewCell.identifier, for: indexPath) as? MyYelloKeywordTableViewCell else { return UITableViewCell() }
                 
                 keywordCell.configureKeywordCell(MyYelloListView.myYelloModelDummy[indexPath.row])
                 keywordCell.selectionStyle = .none
                 return keywordCell
+            } else if MyYelloListView.myYelloModelDummy[indexPath.row].isHintUsed == false && MyYelloListView.myYelloModelDummy[indexPath.row].nameHint == -2 {
+                guard let onlyNameCell = tableView.dequeueReusableCell(withIdentifier: MyYelloOnlyNameTableViewCell.identifier, for: indexPath) as? MyYelloOnlyNameTableViewCell else { return UITableViewCell() }
+                
+                onlyNameCell.configureOnlyNameCell(MyYelloListView.myYelloModelDummy[indexPath.row])
+                onlyNameCell.selectionStyle = .none
+                return onlyNameCell
             } else {
                 guard let nameCell = tableView.dequeueReusableCell(withIdentifier: MyYelloNameTableViewCell.identifier, for: indexPath) as? MyYelloNameTableViewCell else { return UITableViewCell() }
                 
@@ -189,15 +194,18 @@ extension MyYelloListView: UITableViewDataSource {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         if fetchingMore {
             return 77.adjustedHeight
-        }
-        
-        let nameHintIndex = MyYelloListView.myYelloModelDummy[indexPath.row].nameHint
-        
-        if nameHintIndex == 0 || nameHintIndex == 1 || (nameHintIndex == -3 && MyYelloListView.myYelloModelDummy[indexPath.row].isRead == true) {
-            return 98.adjustedHeight
         } else {
-            return 74.adjustedHeight
+            if (MyYelloListView.myYelloModelDummy[indexPath.row].nameHint == -1 && MyYelloListView.myYelloModelDummy[indexPath.row].isHintUsed == false) || (MyYelloListView.myYelloModelDummy[indexPath.row].nameHint == -3 && MyYelloListView.myYelloModelDummy[indexPath.row].isRead == false) {
+                return 74.adjustedHeight
+            } else if MyYelloListView.myYelloModelDummy[indexPath.row].isHintUsed == true && MyYelloListView.myYelloModelDummy[indexPath.row].nameHint == -1 {
+                return 74.adjustedHeight
+            } else if MyYelloListView.myYelloModelDummy[indexPath.row].isHintUsed == false && MyYelloListView.myYelloModelDummy[indexPath.row].nameHint == -2 {
+                return 74.adjustedHeight
+            } else {
+                return 98.adjustedHeight
+            }
         }
+        
     }
     
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/ViewController/MyYelloViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/ViewController/MyYelloViewController.swift
@@ -146,6 +146,13 @@ extension MyYelloViewController {
                 case .success(let data):
                     guard let data = data.data else { return }
                     self.myYelloView.myYelloCount = data.totalCount
+                    if data.ticketCount == 0 {
+                        self.myYelloView.haveTicket = false
+                    } else {
+                        self.myYelloView.haveTicket = true
+                        self.myYelloView.unlockButton.keyCountLabel.text = String(data.ticketCount)
+                    }
+                    
                     print(self.myYelloCount)
                     print("내 옐로 count 통신 성공")
                     self.myYelloView.resetLayout()

--- a/YELLO-iOS/YELLO-iOS/Presentation/Recommending/View/KakaoFriendView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Recommending/View/KakaoFriendView.swift
@@ -189,12 +189,12 @@ extension KakaoFriendView {
                     self.recommendingKakaoFriendTableViewDummy.append(contentsOf: uniqueFriendModels)
                     self.fetchingMore = false
                     
-                    self.kakaoFriendTableView.reloadData()
-                    
                     let totalPage = (data.totalCount) / 100
                     if self.kakaoPage >= totalPage {
                         self.isFinishPaging = true
                     }
+                    
+                    self.kakaoFriendTableView.reloadData()
                     self.updateView()
                     print("통신 성공")
                 default:
@@ -304,16 +304,20 @@ extension KakaoFriendView: UITableViewDataSource {
             cell.showShimmer()
             return cell
         } else {
-            let cell = tableView.dequeueReusableCell(withIdentifier: FriendTableViewCell.identifier, for: indexPath) as! FriendTableViewCell
-            
-            cell.selectionStyle = .none
-            
-            cell.isTapped = self.recommendingKakaoFriendTableViewDummy[indexPath.row].isButtonSelected
-            cell.updateAddButtonImage()
-            
-            cell.handleAddFriendButton = self
-            cell.configureFriendCell(self.recommendingKakaoFriendTableViewDummy[indexPath.row])
-            return cell
+            if indexPath.row < recommendingKakaoFriendTableViewDummy.count {
+                let cell = tableView.dequeueReusableCell(withIdentifier: FriendTableViewCell.identifier, for: indexPath) as! FriendTableViewCell
+                
+                cell.selectionStyle = .none
+                
+                cell.isTapped = self.recommendingKakaoFriendTableViewDummy[indexPath.row].isButtonSelected
+                cell.updateAddButtonImage()
+                
+                cell.handleAddFriendButton = self
+                cell.configureFriendCell(self.recommendingKakaoFriendTableViewDummy[indexPath.row])
+                return cell
+            } else {
+                return UITableViewCell()
+            }
         }
     }
     

--- a/YELLO-iOS/YELLO-iOS/Presentation/Recommending/View/SchoolFriendView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Recommending/View/SchoolFriendView.swift
@@ -279,16 +279,20 @@ extension SchoolFriendView: UITableViewDataSource {
             cell.showShimmer()
             return cell
         } else {
-            let cell = tableView.dequeueReusableCell(withIdentifier: FriendTableViewCell.identifier, for: indexPath) as! FriendTableViewCell
-            
-            cell.selectionStyle = .none
-            
-            cell.isTapped = self.recommendingSchoolFriendTableViewDummy[indexPath.row].isButtonSelected
-            cell.updateAddButtonImage()
-            
-            cell.handleAddFriendButton = self
-            cell.configureFriendCell(self.recommendingSchoolFriendTableViewDummy[indexPath.row])
-            return cell
+            if indexPath.row < recommendingSchoolFriendTableViewDummy.count {
+                let cell = tableView.dequeueReusableCell(withIdentifier: FriendTableViewCell.identifier, for: indexPath) as! FriendTableViewCell
+                
+                cell.selectionStyle = .none
+                
+                cell.isTapped = self.recommendingSchoolFriendTableViewDummy[indexPath.row].isButtonSelected
+                cell.updateAddButtonImage()
+                
+                cell.handleAddFriendButton = self
+                cell.configureFriendCell(self.recommendingSchoolFriendTableViewDummy[indexPath.row])
+                return cell
+            } else {
+                return UITableViewCell()
+            }
         }
     }
 


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- API 연결에 따라 내 옐로에서 구독 여부와 열람권 유무에 따른 UI를 변경했습니다.
<!--
```
작성한 코드가 있다면 여기에 주석을 제거하고 적어주세요!
```
-->


## 📌 PR Point!
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 없습니다..아마도


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    키워드 -> 초성 -> 이름    |   키워드 -> 이름   |   이름 -> 키워드   |
| :-------------: | :----------: | :----------: |
| ![Simulator Screen Recording - iPhone SE (3rd generation) - 2023-08-18 at 22 41 02](https://github.com/team-yello/YELLO-iOS/assets/109775321/84eb4dbe-2cb0-4f61-a35d-32874e16a50a)  | ![Simulator Screen Recording - iPhone SE (3rd generation) - 2023-08-18 at 22 41 15](https://github.com/team-yello/YELLO-iOS/assets/109775321/7bc0fac6-84b7-4039-828f-6bf5380d2431)  |![Simulator Screen Recording - iPhone SE (3rd generation) - 2023-08-18 at 22 52 13](https://github.com/team-yello/YELLO-iOS/assets/109775321/a208074c-86d4-4747-a60e-ac279b052d7f)  |


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #205 
