### PR TITLE
Fix [213] 토큰 로직 수정

### DIFF
--- a/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
+++ b/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		36C209F02A8B6A39001BF12C /* FirstTutorialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36C209EF2A8B6A38001BF12C /* FirstTutorialView.swift */; };
 		36C209F22A8B6E03001BF12C /* TutorialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36C209F12A8B6E03001BF12C /* TutorialViewController.swift */; };
 		36C209F62A8B8190001BF12C /* SecondTutorialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36C209F52A8B8190001BF12C /* SecondTutorialView.swift */; };
+		36C5E1CD2A91273400184AAE /* TokenRefreshRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36C5E1CC2A91273400184AAE /* TokenRefreshRequestDTO.swift */; };
 		36E2181E2A5D17D000FB3C9C /* SearchBaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E2181D2A5D17D000FB3C9C /* SearchBaseViewController.swift */; };
 		36E218202A5D2E3B00FB3C9C /* SearchResultTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E2181F2A5D2E3B00FB3C9C /* SearchResultTableViewCell.swift */; };
 		36E427692A5BCE860050B34E /* FriendsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E427582A5BCE860050B34E /* FriendsTableViewCell.swift */; };
@@ -401,6 +402,7 @@
 		36C209F12A8B6E03001BF12C /* TutorialViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialViewController.swift; sourceTree = "<group>"; };
 		36C209F52A8B8190001BF12C /* SecondTutorialView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondTutorialView.swift; sourceTree = "<group>"; };
 		36C5E1CB2A8FCBAC00184AAE /* Config_dev.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config_dev.xcconfig; sourceTree = "<group>"; };
+		36C5E1CC2A91273400184AAE /* TokenRefreshRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenRefreshRequestDTO.swift; sourceTree = "<group>"; };
 		36E2181D2A5D17D000FB3C9C /* SearchBaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBaseViewController.swift; sourceTree = "<group>"; };
 		36E2181F2A5D2E3B00FB3C9C /* SearchResultTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultTableViewCell.swift; sourceTree = "<group>"; };
 		36E427582A5BCE860050B34E /* FriendsTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FriendsTableViewCell.swift; sourceTree = "<group>"; };
@@ -791,6 +793,7 @@
 				3662A0F52A654B8D00F482EF /* JoinedFriendsRequestDTO.swift */,
 				36871C7C2A664CD8001CA514 /* JoinedFriendsRequestQueryDTO.swift */,
 				3662A0F72A6577E000F482EF /* IdValidRequestQueryDTO.swift */,
+				36C5E1CC2A91273400184AAE /* TokenRefreshRequestDTO.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -2036,6 +2039,7 @@
 				C3FF249B2A5EE46500A97D40 /* MyYelloDetailViewController.swift in Sources */,
 				C3A799EA2A494D6800D3EFD8 /* UIView+.swift in Sources */,
 				2A8AA7072A65150B005A664D /* VotingAnswerListResponseDTO.swift in Sources */,
+				36C5E1CD2A91273400184AAE /* TokenRefreshRequestDTO.swift in Sources */,
 				C3D266452A5C776F0041C7C7 /* ProfileView.swift in Sources */,
 				2A8AA7052A6514F2005A664D /* VotingAnswerListRequestDTO.swift in Sources */,
 				36C209F22A8B6E03001BF12C /* TutorialViewController.swift in Sources */,

--- a/YELLO-iOS/YELLO-iOS/Network/Around/Router/AroundTarget.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Around/Router/AroundTarget.swift
@@ -14,10 +14,17 @@ enum AroundTarget {
 }
 
 extension AroundTarget: TargetType {
+    var authorization: Authorization {
+        switch self {
+        case .around(_):
+            return .authorization
+        }
+    }
+    
     var headerType: HTTPHeaderType {
         switch self {
         case .around(_):
-            return .hasAccessToken
+            return .plain
         }
     }
     

--- a/YELLO-iOS/YELLO-iOS/Network/Base/APIRequestLoader.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Base/APIRequestLoader.swift
@@ -13,6 +13,7 @@ class APIRequestLoader<T: TargetType> {
     private let configuration: URLSessionConfiguration
     private let apiLogger: APIEventLogger
     private let session: Session
+    private let interceptorSession: Session
     let interceptor = MyRequestInterceptor()
     
     init(
@@ -22,7 +23,8 @@ class APIRequestLoader<T: TargetType> {
         self.configuration = configuration
         self.apiLogger = apiLogger
         
-        session = Session(configuration: configuration, interceptor: interceptor, eventMonitors: [apiLogger])
+        session = Session(configuration: configuration, eventMonitors: [apiLogger])
+        interceptorSession = Session(configuration: configuration, interceptor: interceptor, eventMonitors: [apiLogger])
         
     }
     

--- a/YELLO-iOS/YELLO-iOS/Network/Base/HTTPHeaderFieldKey.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Base/HTTPHeaderFieldKey.swift
@@ -13,6 +13,8 @@ enum HTTPHeaderFieldKey: String {
     case acceptType = "Accept"
     case accessToken = "accessToken"
     case refreshtoken = "refreshtoken"
+    case xAccessAuth = "X-ACCESS-AUTH"
+    case xRefreshAuth = "X-REFRESH-AUTH"
 }
 
 enum HTTPHeaderFieldValue: String {
@@ -22,6 +24,12 @@ enum HTTPHeaderFieldValue: String {
 
 enum HTTPHeaderType {
     case plain
-    case hasAccessToken
     case hasToken
+    case refreshToken
+}
+
+@frozen
+enum Authorization {
+    case authorization
+    case unauthorization
 }

--- a/YELLO-iOS/YELLO-iOS/Network/Base/TargetType.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Base/TargetType.swift
@@ -15,6 +15,7 @@ protocol TargetType: URLRequestConvertible {
     var path: String { get }
     var parameters: RequestParams { get }
     var headerType: HTTPHeaderType { get }
+    var authorization: Authorization { get }
 }
 
 extension TargetType {
@@ -48,6 +49,13 @@ extension TargetType {
             url: url.appendingPathComponent(path),
             method: method
         )
+        
+        switch authorization {
+        case .authorization:
+            urlRequest.setValue("Bearer \(KeychainHandler.shared.accessToken)", forHTTPHeaderField: HTTPHeaderFieldKey.authentication.rawValue)
+        case .unauthorization:
+            break
+        }
         
         switch headerType {
         case .plain:

--- a/YELLO-iOS/YELLO-iOS/Network/Base/TargetType.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Base/TargetType.swift
@@ -28,16 +28,17 @@ extension TargetType {
             return [
                 HTTPHeaderFieldKey.contentType.rawValue: HTTPHeaderFieldValue.json.rawValue
             ]
-        case .hasAccessToken:
-            return [
-                HTTPHeaderFieldKey.contentType.rawValue: HTTPHeaderFieldValue.json.rawValue,
-                HTTPHeaderFieldKey.authentication.rawValue: KeychainHandler.shared.accessToken
-            ]
         case .hasToken:
             return [
                 HTTPHeaderFieldKey.contentType.rawValue: HTTPHeaderFieldValue.json.rawValue,
                 HTTPHeaderFieldKey.accessToken.rawValue: "Bearer \(KeychainHandler.shared.accessToken)",
-                HTTPHeaderFieldKey.refreshtoken.rawValue: "Bearer \(KeychainHandler.shared.refreshToken)" 
+                HTTPHeaderFieldKey.refreshtoken.rawValue: "Bearer \(KeychainHandler.shared.refreshToken)"
+            ]
+        case .refreshToken:
+            return [
+                HTTPHeaderFieldKey.contentType.rawValue: HTTPHeaderFieldValue.json.rawValue,
+                HTTPHeaderFieldKey.xAccessAuth.rawValue: "Bearer \(KeychainHandler.shared.accessToken)",
+                HTTPHeaderFieldKey.xRefreshAuth.rawValue: "Bearer \(KeychainHandler.shared.refreshToken)"
             ]
         }
     }
@@ -45,6 +46,7 @@ extension TargetType {
 extension TargetType {
     func asURLRequest() throws -> URLRequest {
         let url = try baseURL.asURL()
+        let accessToken = KeychainHandler.shared.accessToken
         var urlRequest = try URLRequest(
             url: url.appendingPathComponent(path),
             method: method
@@ -60,16 +62,16 @@ extension TargetType {
         switch headerType {
         case .plain:
             urlRequest.setValue(HTTPHeaderFieldValue.json.rawValue, forHTTPHeaderField: HTTPHeaderFieldKey.contentType.rawValue)
-        case .hasAccessToken:
-            urlRequest.setValue(HTTPHeaderFieldValue.json.rawValue, forHTTPHeaderField: HTTPHeaderFieldKey.contentType.rawValue)
-            urlRequest.setValue(KeychainHandler.shared.accessToken, forHTTPHeaderField: HTTPHeaderFieldKey.authentication.rawValue)
         case .hasToken:
             urlRequest.setValue(HTTPHeaderFieldValue.json.rawValue, forHTTPHeaderField: HTTPHeaderFieldKey.contentType.rawValue)
             urlRequest.setValue(KeychainHandler.shared.accessToken, forHTTPHeaderField: HTTPHeaderFieldKey.accessToken.rawValue)
             urlRequest.setValue(KeychainHandler.shared.refreshToken, forHTTPHeaderField: HTTPHeaderFieldKey.refreshtoken.rawValue)
-            
+        case.refreshToken:
+            urlRequest.setValue(HTTPHeaderFieldValue.json.rawValue, forHTTPHeaderField: HTTPHeaderFieldKey.contentType.rawValue)
+            urlRequest.setValue("Bearer \(KeychainHandler.shared.accessToken)", forHTTPHeaderField: HTTPHeaderFieldKey.xAccessAuth.rawValue)
+            urlRequest.setValue("Bearer \(KeychainHandler.shared.refreshToken)", forHTTPHeaderField: HTTPHeaderFieldKey.xRefreshAuth.rawValue)
         }
-
+        
         switch parameters {
         case .requestWithBody(let request):
             let params = request?.toDictionary() ?? [:]

--- a/YELLO-iOS/YELLO-iOS/Network/MyYello/Router/MyYelloTarget.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/MyYello/Router/MyYelloTarget.swift
@@ -19,20 +19,37 @@ enum MyYelloTarget {
 }
 
 extension MyYelloTarget: TargetType {
+    var authorization: Authorization {
+        switch self {
+        case .myYello:
+            return .authorization
+        case .myYelloDetail:
+            return .authorization
+        case .myYelloDetailKeyword:
+            return .authorization
+        case .myYelloDetailName:
+            return .authorization
+        case .myYelloDetailFullName:
+            return .authorization
+        case .payCheck:
+            return .authorization
+        }
+    }
+    
     var headerType: HTTPHeaderType {
         switch self {
         case .myYello:
-            return .hasAccessToken
+            return .plain
         case .myYelloDetail:
-            return .hasAccessToken
+            return .plain
         case .myYelloDetailKeyword:
-            return .hasAccessToken
+            return .plain
         case .myYelloDetailName:
-            return .hasAccessToken
+            return .plain
         case .myYelloDetailFullName:
-            return .hasAccessToken
+            return .plain
         case .payCheck:
-            return .hasAccessToken
+            return .plain
         }
     }
     

--- a/YELLO-iOS/YELLO-iOS/Network/Onboarding/DTO/Request/TokenRefreshRequestDTO.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Onboarding/DTO/Request/TokenRefreshRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  TokenRefreshRequestDTO.swift
+//  YELLO-iOS
+//
+//  Created by 지희의 MAC on 2023/08/20.
+//
+
+import Foundation
+
+struct TokenRefreshRequestDTO: Codable {
+    let accessToken, refreshToken: String
+}

--- a/YELLO-iOS/YELLO-iOS/Network/Onboarding/DTO/Response/TokenRefreshResponseDTO.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Onboarding/DTO/Response/TokenRefreshResponseDTO.swift
@@ -9,17 +9,5 @@ import Foundation
 
 // MARK: - SignUpResponseDTO
 struct TokenRefreshResponseDTO: Codable {
-    let status: Int
-    let message: String
-    let data: DataClass
+    let accessToken, refreshToken : String
 }
-
-// MARK: - DataClass
-struct DataClass: Codable {
-    let accessToken, refreshToken: String
-}
-
-//// MARK: - KakaoLoginRequestDTO
-//struct TokenRefreshResponseDTO: Codable {
-//    let accessToken, refreshToken : String
-//}

--- a/YELLO-iOS/YELLO-iOS/Network/Onboarding/Router/OnboardingTarget.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Onboarding/Router/OnboardingTarget.swift
@@ -16,7 +16,7 @@ enum OnboardingTarget {
     case getCheckDuplicate(_ dto: IdValidRequestQueryDTO) /// 아이디 중복 확인
     case postFirendsList( _ query: JoinedFriendsRequestQueryDTO, _ dto: JoinedFriendsRequestDTO) /// 가입한 친구 목록 불러오기
     case postUserInfo(_ dto: SignUpRequestDTO ) /// 회원가입
-    case postRefreshToken
+    case postRefreshToken(_ dto: TokenRefreshRequestDTO)
 }
 
 extension OnboardingTarget: TargetType {

--- a/YELLO-iOS/YELLO-iOS/Network/Onboarding/Router/OnboardingTarget.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Onboarding/Router/OnboardingTarget.swift
@@ -20,6 +20,25 @@ enum OnboardingTarget {
 }
 
 extension OnboardingTarget: TargetType {
+    var authorization: Authorization {
+        switch self {
+        case .postTokenChange:
+            return .unauthorization
+        case .getSchoolList:
+            return .unauthorization
+        case .getMajorList:
+            return .unauthorization
+        case .getCheckDuplicate:
+            return .unauthorization
+        case .postFirendsList:
+            return .unauthorization
+        case .postUserInfo:
+            return .unauthorization
+        case .postRefreshToken:
+            return .unauthorization
+        }
+    }
+    
     var headerType: HTTPHeaderType {
         switch self {
         case .postTokenChange:
@@ -29,13 +48,13 @@ extension OnboardingTarget: TargetType {
         case .getMajorList:
             return .plain
         case .getCheckDuplicate:
-            return .hasAccessToken
+            return .plain
         case .postFirendsList:
             return .plain
         case .postUserInfo:
-            return .hasAccessToken
+            return .plain
         case .postRefreshToken:
-            return .hasToken
+            return .refreshToken
         }
     }
     
@@ -91,8 +110,8 @@ extension OnboardingTarget: TargetType {
             return .requestQuery(dto)
         case .postFirendsList(let query, let dto):
             return .requestQueryWithBody(query, bodyParameter: dto)
-        case .postRefreshToken:
-            return .requestPlain
+        case .postRefreshToken(let dto):
+            return .requestWithBody(dto)
         }
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Network/Onboarding/Service/OnboardingService.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Onboarding/Service/OnboardingService.swift
@@ -16,7 +16,7 @@ protocol OnboardingServiceProtocol {
     func getSchoolList(queryDTO: SchoolSearchRequestQueryDTO, completion: @escaping (NetworkResult<BaseResponse<SchoolSearchResponseDTO>>) -> Void)
     func getMajorList(queryDTO: MajorSearchRequestQueryDTO, completion: @escaping (NetworkResult<BaseResponse<MajorSearchResponseDTO>>) -> Void)
     func postJoinedFriends(queryDTO: JoinedFriendsRequestQueryDTO, requestDTO: JoinedFriendsRequestDTO, completion: @escaping (NetworkResult<BaseResponse<JoinedFriendsResponseDTO>>) -> Void)
-    func postRefreshToken(completion: @escaping (NetworkResult<BaseResponse<TokenRefreshResponseDTO>>)->Void)
+    func postRefreshToken(requsetDTO: TokenRefreshRequestDTO, completion: @escaping (NetworkResult<BaseResponse<TokenRefreshResponseDTO>>)->Void)
 }
 
 final class OnboardingService: APIRequestLoader<OnboardingTarget>, OnboardingServiceProtocol {
@@ -45,8 +45,8 @@ final class OnboardingService: APIRequestLoader<OnboardingTarget>, OnboardingSer
         fetchData(target: .postFirendsList(queryDTO, requestDTO), responseData: BaseResponse<JoinedFriendsResponseDTO>.self, completion: completion)
     }
     
-    func postRefreshToken(completion: @escaping (NetworkResult<BaseResponse<TokenRefreshResponseDTO>>) -> Void) {
-        fetchData(target: .postRefreshToken, responseData: BaseResponse<TokenRefreshResponseDTO>.self, completion: completion)
+    func postRefreshToken(requsetDTO: TokenRefreshRequestDTO, completion: @escaping (NetworkResult<BaseResponse<TokenRefreshResponseDTO>>)->Void) {
+        fetchData(target: .postRefreshToken(requsetDTO), responseData: BaseResponse<TokenRefreshResponseDTO>.self, completion: completion)
     }
     
 }

--- a/YELLO-iOS/YELLO-iOS/Network/Profile/Router/ProfileTarget.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Profile/Router/ProfileTarget.swift
@@ -18,18 +18,33 @@ enum ProfileTarget {
 }
 
 extension ProfileTarget: TargetType {
+    var authorization: Authorization {
+        switch self {
+        case .profileUser:
+            return .authorization
+        case .profileFriend:
+            return .authorization
+        case .profileDeleteFriend:
+            return .authorization
+        case .deleteUser:
+            return .authorization
+        case .purchaseInfo:
+            return .authorization
+        }
+    }
+    
     var headerType: HTTPHeaderType {
         switch self {
         case .profileUser:
-            return .hasAccessToken
+            return .plain
         case .profileFriend:
-            return .hasAccessToken
+            return .plain
         case .profileDeleteFriend:
-            return .hasAccessToken
+            return .plain
         case .deleteUser:
-            return .hasAccessToken
+            return .plain
         case .purchaseInfo:
-            return .hasAccessToken
+            return .plain
         }
     }
     

--- a/YELLO-iOS/YELLO-iOS/Network/Recommending/Router/RecommendingTarget.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Recommending/Router/RecommendingTarget.swift
@@ -16,14 +16,26 @@ enum RecommendingTarget {
 }
 
 extension RecommendingTarget: TargetType {
+    
+    var authorization: Authorization {
+        switch self {
+        case .recommendingKakaoFriend(_, _):
+            return .authorization
+        case .recommendingSchoolFriend(_):
+            return .authorization
+        case .recommendingAddFriend(_):
+            return .authorization
+        }
+    }
+    
     var headerType: HTTPHeaderType {
         switch self {
         case .recommendingKakaoFriend(_, _):
-            return .hasAccessToken
+            return .plain
         case .recommendingSchoolFriend(_):
-            return .hasAccessToken
+            return .plain
         case .recommendingAddFriend(_):
-            return .hasAccessToken
+            return .plain
         }
     }
     

--- a/YELLO-iOS/YELLO-iOS/Network/Search/Router/SearchTarget.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Search/Router/SearchTarget.swift
@@ -14,6 +14,14 @@ enum SearchTarget {
 }
 
 extension SearchTarget: TargetType {
+    
+    var authorization: Authorization {
+        switch self {
+        case .friendSearch:
+            return .authorization
+        }
+    }
+    
     var headerType: HTTPHeaderType {
         switch self {
         case .friendSearch:

--- a/YELLO-iOS/YELLO-iOS/Network/Voting/Router/VotingTarget.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Voting/Router/VotingTarget.swift
@@ -18,18 +18,33 @@ enum VotingTarget {
 }
 
 extension VotingTarget: TargetType {
+    var authorization: Authorization {
+        switch self {
+        case .getVotingAvailable:
+            return .authorization
+        case .getVotingSuffle:
+            return .authorization
+        case .getVotingList:
+            return .authorization
+        case .postVotingAnswerList:
+            return .authorization
+        case .getUnreadCount:
+            return .authorization
+        }
+    }
+    
     var headerType: HTTPHeaderType {
         switch self {
         case .getVotingAvailable:
-            return .hasAccessToken
+            return .plain
         case .getVotingSuffle:
-            return .hasAccessToken
+            return .plain
         case .getVotingList:
-            return .hasAccessToken
+            return .plain
         case .postVotingAnswerList:
-            return .hasAccessToken
+            return .plain
         case .getUnreadCount:
-            return .hasAccessToken
+            return .plain
         }
     }
     


### PR DESCRIPTION
## ⛏ 작업 내용
토큰 로직을 수정했습니다. 

## 📌 PR Point!
- 인터셉터를 제거하고 인가가 필요한 API인 경우 `Authorization`을 추가하는 방식을 이용했습니다. 앞으로 API 붙일 때 같이 설정해주세요!
```swift
extension AroundTarget: TargetType {
    var authorization: Authorization {
        switch self {
        case .around(_):
            return .authorization
        }
    }
```
- refreshToken의 requesst body를 추가했습니다. 
- 토큰 재발급을 3번까지 시도하고 되지 않은 경우 / 서버 응답이 403인 경우 로그아웃을 하도록 구현했습니다. 
```swift
func logout(){
        UserApi.shared.logout {(error) in
            if let error = error {
                print(error)
            } else {
                print("logout() success.")
                let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as! SceneDelegate
                
                UserDefaults.standard.removeObject(forKey: "isLoggined")
                User.shared.isResigned = false
                User.shared.isFirstUser = false
                
                KeychainHandler.shared.refreshToken = ""
                KeychainHandler.shared.accessToken = ""
                
                UserDefaults.standard.removeObject(forKey: "isLoggined")
                sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: KakaoLoginViewController())
                
                
               sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: KakaoLoginViewController())
            }
            
        }
    }
```


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 토큰 로직 | 없습니다 |


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #213 
