### PR TITLE
Feat [#212] 앱스토어 강제 업데이트 설정

### DIFF
--- a/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
+++ b/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		C31315B22A7CBA6F00FB8B43 /* MyYelloButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31315B12A7CBA6F00FB8B43 /* MyYelloButton.swift */; };
 		C32322F52A619E92006DA50B /* PaymentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C32322F42A619E92006DA50B /* PaymentView.swift */; };
 		C32322F92A61ABF2006DA50B /* PaymentCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C32322F82A61ABF2006DA50B /* PaymentCollectionViewCell.swift */; };
+		C3291A082A920D84007F2CF5 /* AppStoreCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3291A072A920D84007F2CF5 /* AppStoreCheck.swift */; };
 		C348B6D72A8FBBD600674371 /* PurchaseInfoResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = C348B6D62A8FBBD600674371 /* PurchaseInfoResponseDTO.swift */; };
 		C363D46D2A78050600FD583D /* AroundTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C363D46C2A78050600FD583D /* AroundTableViewCell.swift */; };
 		C363D4722A780F0D00FD583D /* AroundEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C363D4712A780F0D00FD583D /* AroundEmptyView.swift */; };
@@ -453,6 +454,7 @@
 		C31315B12A7CBA6F00FB8B43 /* MyYelloButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyYelloButton.swift; sourceTree = "<group>"; };
 		C32322F42A619E92006DA50B /* PaymentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentView.swift; sourceTree = "<group>"; };
 		C32322F82A61ABF2006DA50B /* PaymentCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentCollectionViewCell.swift; sourceTree = "<group>"; };
+		C3291A072A920D84007F2CF5 /* AppStoreCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreCheck.swift; sourceTree = "<group>"; };
 		C348B6D62A8FBBD600674371 /* PurchaseInfoResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseInfoResponseDTO.swift; sourceTree = "<group>"; };
 		C363D46C2A78050600FD583D /* AroundTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AroundTableViewCell.swift; sourceTree = "<group>"; };
 		C363D4712A780F0D00FD583D /* AroundEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AroundEmptyView.swift; sourceTree = "<group>"; };
@@ -1057,6 +1059,7 @@
 			children = (
 				36EA2AB62A66FC0B003603C7 /* User.swift */,
 				C306E7262A630BB70031514C /* KeychainHandler.swift */,
+				C3291A072A920D84007F2CF5 /* AppStoreCheck.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -2079,6 +2082,7 @@
 				C3B472122A65E17E00770530 /* MyYelloDetailNameResponseDTO.swift in Sources */,
 				C3D2664C2A5D1F4C0041C7C7 /* ProfileSettingViewController.swift in Sources */,
 				367113732A7D6CED0037E0D2 /* UniversityViewController.swift in Sources */,
+				C3291A082A920D84007F2CF5 /* AppStoreCheck.swift in Sources */,
 				3662A0F62A654B8D00F482EF /* JoinedFriendsRequestDTO.swift in Sources */,
 				C3C57BC12A56FCA600B84CAA /* AroundView.swift in Sources */,
 				C3C57BC52A5715E600B84CAA /* KakaoFriendViewController.swift in Sources */,

--- a/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
+++ b/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
@@ -1758,9 +1758,9 @@
 				C3FF24922A5E903C00A97D40 /* MyYelloDefaultTableViewCell.swift */,
 				C3FF24942A5E906B00A97D40 /* MyYelloKeywordTableViewCell.swift */,
 				C3FF24962A5E907D00A97D40 /* MyYelloNameTableViewCell.swift */,
-				C3E4B6FE2A68080A001A0355 /* MyYelloEmptyTableViewCell.swift */,
 				C30F81062A7F6A63009DBB8D /* MyYelloOnlyNameTableViewCell.swift */,
 				C38A93ED2A83910400B9110B /* MyYelloSkeletonTableViewCell.swift */,
+				C3E4B6FE2A68080A001A0355 /* MyYelloEmptyTableViewCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";

--- a/YELLO-iOS/YELLO-iOS/Application/SceneDelegate.swift
+++ b/YELLO-iOS/YELLO-iOS/Application/SceneDelegate.swift
@@ -231,7 +231,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func showUpdateAlert(version: String) {
         let alert = UIAlertController(
             title: "업데이트 알림",
-            message: "YELL:O의 새로운 버전이 있습니다. \(version) 버전으로 업데이트 해주세요.",
+            message: "더 나은 서비스를 위해 옐로가 수정되었어요! 업데이트해주시겠어요?",
             preferredStyle: .alert
         )
         

--- a/YELLO-iOS/YELLO-iOS/Application/SceneDelegate.swift
+++ b/YELLO-iOS/YELLO-iOS/Application/SceneDelegate.swift
@@ -41,6 +41,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     navigationController.navigationBar.isHidden = true
                     self.window?.rootViewController = navigationController
                     self.window?.makeKeyAndVisible()
+                    self.checkAndUpdateIfNeeded()
                 } else {
                     if self.isLoggined {
                         let yelloTabBarController = YELLOTabBarController()
@@ -48,12 +49,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                         navigationController.navigationBar.isHidden = true
                         self.window?.rootViewController = navigationController
                         self.window?.makeKeyAndVisible()
+                        self.checkAndUpdateIfNeeded()
                     } else {
                         let kakaologinViewController = KakaoLoginViewController()
                         let navigationController = UINavigationController(rootViewController: kakaologinViewController)
                         navigationController.navigationBar.isHidden = true
                         self.window?.rootViewController = navigationController
                         self.window?.makeKeyAndVisible()
+                        self.checkAndUpdateIfNeeded()
                     }
                 }
                 return
@@ -71,11 +74,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     rootViewController.selectedIndex = selectedIndex
                     self.window?.rootViewController = navigationController
                     self.window?.makeKeyAndVisible()
+                    self.checkAndUpdateIfNeeded()
                 } else if type == StringLiterals.PushAlarm.TypeName.newFriend {
                     selectedIndex = 4
                     rootViewController.selectedIndex = selectedIndex
                     self.window?.rootViewController = navigationController
                     self.window?.makeKeyAndVisible()
+                    self.checkAndUpdateIfNeeded()
                 }
                 return
             }
@@ -84,6 +89,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let navigationController = UINavigationController(rootViewController: rootViewController)
             self.window?.rootViewController = navigationController
             self.window?.makeKeyAndVisible()
+            self.checkAndUpdateIfNeeded()
             
             if type == StringLiterals.PushAlarm.TypeName.newVote {
                 selectedIndex = 3
@@ -93,7 +99,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     switch response {
                     case .success(let data):
                         guard let data = data.data else { return }
-
+                        
                         myYelloDetailViewController.colorIndex = data.colorIndex
                         myYelloDetailViewController.myYelloDetailView.currentPoint = data.currentPoint
                         myYelloDetailViewController.myYelloDetailView.detailSenderView.isHidden = false
@@ -103,25 +109,25 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                         myYelloDetailViewController.myYelloDetailView.keywordButton.isHidden = false
                         myYelloDetailViewController.myYelloDetailView.senderButton.isHidden = false
                         myYelloDetailViewController.setBackgroundView()
-
+                        
                         if data.senderGender == "MALE" {
                             myYelloDetailViewController.myYelloDetailView.genderLabel.text = StringLiterals.MyYello.Detail.male
                         } else {
                             myYelloDetailViewController.myYelloDetailView.genderLabel.text = StringLiterals.MyYello.Detail.female
                         }
-
+                        
                         if data.vote.nameHead == nil {
                             myYelloDetailViewController.myYelloDetailView.detailKeywordView.nameKeywordLabel.text = "너" + (data.vote.nameFoot ?? "")
                         } else {
                             myYelloDetailViewController.myYelloDetailView.detailKeywordView.nameKeywordLabel.text = (data.vote.nameHead ?? "") + " 너" + (data.vote.nameFoot ?? "")
                         }
-
+                        
                         myYelloDetailViewController.myYelloDetailView.detailKeywordView.keywordHeadLabel.text = (data.vote.keywordHead ?? "")
                         myYelloDetailViewController.myYelloDetailView.detailKeywordView.keywordLabel.text = data.vote.keyword
                         myYelloDetailViewController.myYelloDetailView.detailKeywordView.keywordFootLabel.text = (data.vote.keywordFoot ?? "")
-
+                        
                         myYelloDetailViewController.myYelloDetailView.isKeywordUsed = data.isAnswerRevealed
-
+                        
                         if data.nameHint == 0 {
                             myYelloDetailViewController.myYelloDetailView.isSenderUsed = true
                             if let initial = myYelloDetailViewController.getFirstInitial(data.senderName as NSString, index: 0) {
@@ -190,6 +196,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
+        checkAndUpdateIfNeeded()
     }
     
     func sceneDidEnterBackground(_ scene: UIScene) {
@@ -200,6 +207,40 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Save the class name of topViewController to UserDefaults
         let className = "\(String(describing: type(of: topViewController)))"
         UserDefaults.standard.set(className, forKey: "lastViewController")
+    }
+    
+    func checkAndUpdateIfNeeded() {
+        let marketingVersion = AppStoreCheck().latestVersion() ?? ""
+        let currentProjectVersion = AppStoreCheck.appVersion ?? ""
+        let splitMarketingVersion = marketingVersion.split(separator: ".").map { $0 }
+        let splitCurrentProjectVersion = currentProjectVersion.split(separator: ".").map { $0 }
+        
+        if splitCurrentProjectVersion[0] < splitMarketingVersion[0] {
+            showUpdateAlert(version: marketingVersion)
+        } else if splitCurrentProjectVersion[1] < splitMarketingVersion[1] {
+            showUpdateAlert(version: marketingVersion)
+        } else {
+            print(marketingVersion)
+            print(currentProjectVersion)
+            print(splitMarketingVersion)
+            print(splitCurrentProjectVersion)
+            print("현재 최신 버젼입니다.")
+        }
+    }
+    
+    func showUpdateAlert(version: String) {
+        let alert = UIAlertController(
+            title: "업데이트 알림",
+            message: "YELL:O의 새로운 버전이 있습니다. \(version) 버전으로 업데이트 해주세요.",
+            preferredStyle: .alert
+        )
+        
+        let updateAction = UIAlertAction(title: "업데이트", style: .default) { _ in
+            AppStoreCheck().openAppStore()
+        }
+        
+        alert.addAction(updateAction)
+        window?.rootViewController?.present(alert, animated: true, completion: nil)
     }
 }
 

--- a/YELLO-iOS/YELLO-iOS/Global/Shared/AppStoreCheck.swift
+++ b/YELLO-iOS/YELLO-iOS/Global/Shared/AppStoreCheck.swift
@@ -13,7 +13,7 @@ class AppStoreCheck {
     static let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
     // 개발자가 내부적으로 확인하기 위한 용도 : 타겟 -> 일반 -> Build
     static let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
-    static let appStoreOpenUrlString = "itms-apps://itunes.apple.com/app/apple-store/AppleID"
+    static let appStoreOpenUrlString = "itms-apps://itunes.apple.com/app/apple-store/6451451050"
     
     // 앱 스토어 최신 정보 확인
     func latestVersion() -> String? {

--- a/YELLO-iOS/YELLO-iOS/Global/Shared/AppStoreCheck.swift
+++ b/YELLO-iOS/YELLO-iOS/Global/Shared/AppStoreCheck.swift
@@ -1,0 +1,40 @@
+//
+//  AppStoreCheck.swift
+//  YELLO-iOS
+//
+//  Created by 정채은 on 2023/08/20.
+//
+
+import Foundation
+
+enum VersionError: Error {
+    case invalidResponse, invalidBundleInfo
+}
+
+class AppStoreCheck {
+    static func isUpdateAvailable(completion: @escaping (Bool?, Error?) -> Void) throws -> URLSessionDataTask {
+        guard let info = Bundle.main.infoDictionary,
+            let currentVersion = info["CFBundleShortVersionString"] as? String, // 현재 버전
+            let identifier = info["CFBundleIdentifier"] as? String,
+            let url = URL(string: "http://itunes.apple.com/kr/lookup?bundleId=\(identifier)") else {
+                throw VersionError.invalidBundleInfo
+        }
+        let task = URLSession.shared.dataTask(with: url) { (data, response, error) in
+            do {
+                if let error = error { throw error }
+                guard let data = data else { throw VersionError.invalidResponse }
+                let json = try JSONSerialization.jsonObject(with: data, options: [.allowFragments]) as? [String: Any]
+                guard let result = (json?["results"] as? [Any])?.first as? [String: Any], let version = result["version"] as? String else {
+                    throw VersionError.invalidResponse
+                }
+                let verFloat = NSString.init(string: version).floatValue
+                let currentVerFloat = NSString.init(string: currentVersion).floatValue
+                completion(verFloat > currentVerFloat, nil) // 현재 버전이 앱스토어 버전보다 큰지를 Bool값으로 반환
+            } catch {
+                completion(nil, error)
+            }
+        }
+        task.resume()
+        return task
+    }
+}

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloDefaultTableViewCell.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloDefaultTableViewCell.swift
@@ -72,7 +72,7 @@ final class MyYelloDefaultTableViewCell: UITableViewCell {
         }
         
         timeLabel.do {
-            $0.setTextWithLineHeight(text: "1시간 전", lineHeight: 16.adjustedHeight)
+            $0.text = " "
             $0.font = .uiLabelLarge
             $0.textColor = .grayscales600
         }

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloKeywordTableViewCell.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloKeywordTableViewCell.swift
@@ -83,7 +83,7 @@ final class MyYelloKeywordTableViewCell: UITableViewCell {
         }
         
         timeLabel.do {
-            $0.setTextWithLineHeight(text: " ", lineHeight: 16.adjustedHeight)
+            $0.text = " "
             $0.font = .uiLabelLarge
             $0.textColor = .semanticGenderF500
         }

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloNameTableViewCell.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloNameTableViewCell.swift
@@ -61,13 +61,13 @@ final class MyYelloNameTableViewCell: UITableViewCell {
         }
         
         initialLabel.do {
-            $0.setTextWithLineHeight(text: " ", lineHeight: 20.adjustedHeight)
+            $0.text = " "
             $0.font = .uiKeywordBold
             $0.textColor = .semanticGenderF300
         }
         
         sendLabel.do {
-            $0.setTextWithLineHeight(text: StringLiterals.MyYello.List.nameTitle, lineHeight: 20.adjustedHeight)
+            $0.text = StringLiterals.MyYello.List.nameTitle
             $0.font = .uiBodySmall
             $0.textColor = .semanticGenderF300
         }
@@ -97,7 +97,7 @@ final class MyYelloNameTableViewCell: UITableViewCell {
         }
         
         timeLabel.do {
-            $0.setTextWithLineHeight(text: " ", lineHeight: 16.adjustedHeight)
+            $0.text = " "
             $0.font = .uiLabelLarge
             $0.textColor = .semanticGenderF500
         }
@@ -122,11 +122,13 @@ final class MyYelloNameTableViewCell: UITableViewCell {
         
         initialLabel.snp.makeConstraints {
             $0.top.equalToSuperview().inset(13.adjustedHeight)
+            $0.height.equalTo(20.adjustedHeight)
             $0.leading.equalTo(genderImageView.snp.trailing).inset(-12.adjustedWidth)
         }
         
         sendLabel.snp.makeConstraints {
             $0.top.equalTo(initialLabel)
+            $0.height.equalTo(20.adjustedHeight)
             $0.leading.equalTo(initialLabel.snp.trailing).inset(-2.adjustedWidth)
         }
         

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloOnlyNameTableViewCell.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Cells/MyYelloOnlyNameTableViewCell.swift
@@ -75,7 +75,7 @@ final class MyYelloOnlyNameTableViewCell: UITableViewCell {
         }
         
         timeLabel.do {
-            $0.setTextWithLineHeight(text: "1시간 전", lineHeight: 16.adjustedHeight)
+            $0.text = " "
             $0.font = .uiLabelLarge
             $0.textColor = .grayscales600
         }


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- [Major].[Minor].[Patch] 버전 중 Major나 Minor가 달라질 경우 모든 화면에서 강제 업데이트를 하도록 설정해주었습니다.


- https://github.com/team-yello/YELLO-iOS/blob/64ab262285bea0f3cab9e68f1a2b2a0eb2b8aeff/YELLO-iOS/YELLO-iOS/Global/Shared/AppStoreCheck.swift#L12-L13
버젼 정보를 받아오도록 했습니다.
- https://github.com/team-yello/YELLO-iOS/blob/64ab262285bea0f3cab9e68f1a2b2a0eb2b8aeff/YELLO-iOS/YELLO-iOS/Global/Shared/AppStoreCheck.swift#L18-L29
앱스토어의 버전을 받아오는 함수입니다. 
- https://github.com/team-yello/YELLO-iOS/blob/64ab262285bea0f3cab9e68f1a2b2a0eb2b8aeff/YELLO-iOS/YELLO-iOS/Application/SceneDelegate.swift#L212-L229
 Major나 Minor가 다른 경우 알럿이 띄워지도록 했습니다. 
- https://github.com/team-yello/YELLO-iOS/blob/64ab262285bea0f3cab9e68f1a2b2a0eb2b8aeff/YELLO-iOS/YELLO-iOS/Application/SceneDelegate.swift#L196-L200
백그라운드에서 포그라운드로 진입시에도 해당 함수가 실행되며 업데이트를 강제하였습니다.

## 📌 PR Point!
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 현재 버전에 Patch가 없는 상황이며, 이 부분을 추가한 후 Patch도 달라질 경우 강제 업데이트를 시킬 것인지 여부에 대해서 나중에 논의해보면 좋을 것 같습니다. 또한 Major Minor Patch 어떤 식으로 업데이트 기준을 정할 것인지 version convention을 다같이 정해두면 좋을 것 같습니다!
- 내용은 추후 라이팅 정해지면 수정할 예정입니다.  -> 완료

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
|  업데이트 알럿  |  ![Simulator Screenshot - iPhone 11 - 2023-08-21 at 01 48 46](https://github.com/team-yello/YELLO-iOS/assets/109775321/f3480956-294a-44db-9f09-91cdb0ba8fff)  |
|  백그라운드 -> 포그라운드 진입 시에도 확인  |   ![ezgif-4-20f5a64d43](https://github.com/team-yello/YELLO-iOS/assets/109775321/fd83d726-fd63-4ed3-90da-9b5f4149b9c7)  |


|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
|   라이팅 수정된 부분 |   ![IMG_D60359A2CE82-1](https://github.com/team-yello/YELLO-iOS/assets/109775321/72131b71-eb04-46a8-aa42-1c78fa813d7b)    |

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #212 
