### PR TITLE
Fix [#216] 내 옐로 오류 수정

### DIFF
--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/MyYelloDetailView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/MyYelloDetailView.swift
@@ -110,6 +110,8 @@ final class MyYelloDetailView: BaseView {
                     }
                 }
                 
+                self.detailKeywordView.keywordLabel.isHidden = false
+                self.detailKeywordView.questionLabel.isHidden = true
                 MyYelloListView.myYelloModelDummy[indexNumber].isHintUsed = self.isKeywordUsed
                 print("view_open_keyword")
                 Amplitude.instance().logEvent("view_open_keyword")

--- a/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/MyYelloDetailView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/MyYello/Detail/View/MyYelloDetailView.swift
@@ -29,7 +29,7 @@ final class MyYelloDetailView: BaseView {
     var getHintView = GetHintView()
     var useTicketView = UseTicketView()
     var getFullNameView = GetFullNameView()
-    var indexNumber: Int = 0
+    var indexNumber: Int = -1
     var nameIndex: Int = -1
     
     lazy var instagramButton = UIButton(frame: CGRect(x: 0, y: 0, width: 60.adjusted, height: 60.adjusted))
@@ -90,7 +90,9 @@ final class MyYelloDetailView: BaseView {
     var isRead: Bool = false {
         didSet {
             DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.2) {
-                MyYelloListView.myYelloModelDummy[self.indexNumber].isRead = self.isRead
+                if self.indexNumber != -1 {
+                    MyYelloListView.myYelloModelDummy[self.indexNumber].isRead = self.isRead
+                }
             }
         }
     }
@@ -112,7 +114,9 @@ final class MyYelloDetailView: BaseView {
                 
                 self.detailKeywordView.keywordLabel.isHidden = false
                 self.detailKeywordView.questionLabel.isHidden = true
-                MyYelloListView.myYelloModelDummy[indexNumber].isHintUsed = self.isKeywordUsed
+                if self.indexNumber != -1 {
+                    MyYelloListView.myYelloModelDummy[indexNumber].isHintUsed = self.isKeywordUsed
+                }
                 print("view_open_keyword")
                 Amplitude.instance().logEvent("view_open_keyword")
             }
@@ -473,7 +477,9 @@ extension MyYelloDetailView {
                     
                 }
                 self.nameIndex = data.nameIndex
-                MyYelloListView.myYelloModelDummy[self.indexNumber].nameHint = data.nameIndex
+                if self.indexNumber != -1 {
+                    MyYelloListView.myYelloModelDummy[self.indexNumber].nameHint = data.nameIndex
+                }
                 
                 dump(data)
                 print("이름 통신 성공")
@@ -497,9 +503,10 @@ extension MyYelloDetailView {
                 self.getFullNameView.ticketLabel.text = String(self.ticketCount - 1)
                 self.isTicketUsed = true
                 self.senderButton.setButtonState(state: .useTicket)
-
-                MyYelloListView.myYelloModelDummy[self.indexNumber].nameHint = -2
                 
+                if self.indexNumber != -1 {
+                    MyYelloListView.myYelloModelDummy[self.indexNumber].nameHint = -2
+                }
                 dump(data)
                 print("이름 통신 성공")
             default:


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 푸시 알림에서 내 옐로 상세보기로 들어갈 경우 indexNumber의 기본값이 0이어서 첫번째 키워드가 보여지는 문제를 해결하였습니다. 기본값을 -1로 설정하였고, -1일 경우에는 키워드, 초성, 이름이 모두 보여지지 않도록 설정했습니다. 
<!--
```
작성한 코드가 있다면 여기에 주석을 제거하고 적어주세요!
```
-->


## 📌 PR Point!
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 안드와 협의한 사항.. 푸시를 선택하고 리스트로 돌아갔을 때 반영이 되지 않아있습니다. 기술적으로 구현하기 어려운 부분이었기에 내일 QA 진행 후 협의하여 결정하도록 하겠습니다. 


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 화면종류 | 없음 |


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #216 
