### PR TITLE
Fix [#230] 온보딩/디바이스 토큰 서버 변동 사항 적용

### DIFF
--- a/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
+++ b/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		3671136F2A7D3F9D0037E0D2 /* HighSchoolView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3671136E2A7D3F9D0037E0D2 /* HighSchoolView.swift */; };
 		367113712A7D6C740037E0D2 /* UniversityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 367113702A7D6C740037E0D2 /* UniversityView.swift */; };
 		367113732A7D6CED0037E0D2 /* UniversityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 367113722A7D6CED0037E0D2 /* UniversityViewController.swift */; };
+		367229D12A991BC700724494 /* DeviceTokenRefreshRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 367229D02A991BC700724494 /* DeviceTokenRefreshRequestDTO.swift */; };
 		367DA01B2A863CE60043D23C /* HighSchoolViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 367DA01A2A863CE60043D23C /* HighSchoolViewController.swift */; };
 		367DA01D2A86496D0043D23C /* NameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 367DA01C2A86496D0043D23C /* NameViewController.swift */; };
 		367F1CD22A5408E100CDF47B /* Unbounded-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 367F1CD12A5408E100CDF47B /* Unbounded-Bold.ttf */; };
@@ -392,6 +393,7 @@
 		3671136E2A7D3F9D0037E0D2 /* HighSchoolView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighSchoolView.swift; sourceTree = "<group>"; };
 		367113702A7D6C740037E0D2 /* UniversityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversityView.swift; sourceTree = "<group>"; };
 		367113722A7D6CED0037E0D2 /* UniversityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversityViewController.swift; sourceTree = "<group>"; };
+		367229D02A991BC700724494 /* DeviceTokenRefreshRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceTokenRefreshRequestDTO.swift; sourceTree = "<group>"; };
 		367DA01A2A863CE60043D23C /* HighSchoolViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighSchoolViewController.swift; sourceTree = "<group>"; };
 		367DA01C2A86496D0043D23C /* NameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameViewController.swift; sourceTree = "<group>"; };
 		367F1CD12A5408E100CDF47B /* Unbounded-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Unbounded-Bold.ttf"; sourceTree = "<group>"; };
@@ -815,6 +817,7 @@
 				36871C7C2A664CD8001CA514 /* JoinedFriendsRequestQueryDTO.swift */,
 				3662A0F72A6577E000F482EF /* IdValidRequestQueryDTO.swift */,
 				36C5E1CC2A91273400184AAE /* TokenRefreshRequestDTO.swift */,
+				367229D02A991BC700724494 /* DeviceTokenRefreshRequestDTO.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -2088,6 +2091,7 @@
 				C306E7472A656D170031514C /* ProfileFriendRequestQueryDTO.swift in Sources */,
 				2AD1A1AE2A571ED500CB988B /* BaseVotingETCView.swift in Sources */,
 				C3A799E82A494D6800D3EFD8 /* UILabel+.swift in Sources */,
+				367229D12A991BC700724494 /* DeviceTokenRefreshRequestDTO.swift in Sources */,
 				C3B1D8BB2A81208E0050D737 /* FriendSkeletonTableViewCell.swift in Sources */,
 				2AA0DBC32A553788002B1370 /* YELLOTabBarController.swift in Sources */,
 				C3C560D12A8BBE190074E988 /* MyProducts.swift in Sources */,

--- a/YELLO-iOS/YELLO-iOS/Application/AppDelegate.swift
+++ b/YELLO-iOS/YELLO-iOS/Application/AppDelegate.swift
@@ -113,8 +113,21 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 extension AppDelegate: MessagingDelegate {
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         print("FirebaseMessaging")
-        let deviceToken:[String: String] = ["token": fcmToken ?? ""]
-        User.shared.deviceToken = fcmToken ?? ""
-        print("Device token:", deviceToken) // 이 토큰은 FCM에서 알림을 테스트하는 데 사용할 수 있습니다.
+        guard let fcmToken = fcmToken else { return }
+        let deviceToken:[String: String] = ["token": fcmToken]
+        
+        let requestDTO = DeviceTokenRefreshRequestDTO(deviceToken: fcmToken)
+        NetworkService.shared.onboardingService.putRefreshDeviceToken(requsetDTO: requestDTO) { result in
+            switch result {
+            case .success(let data):
+                if data.status == 200 || data.status == 201 {
+                    User.shared.deviceToken = fcmToken
+                }
+            default:
+                print("deviceToken 재발급 오류")
+            }
+        }
+        User.shared.deviceToken = fcmToken
+        print("Device token 재발급 완료:", deviceToken)
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Network/Onboarding/DTO/Request/DeviceTokenRefreshRequestDTO.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Onboarding/DTO/Request/DeviceTokenRefreshRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  DeviceTokenRefreshRequestDTO.swift
+//  YELLO-iOS
+//
+//  Created by 지희의 MAC on 2023/08/26.
+//
+
+import Foundation
+
+// MARK: - SignUpResponseDTO
+struct DeviceTokenRefreshRequestDTO: Codable {
+    let deviceToken: String
+}

--- a/YELLO-iOS/YELLO-iOS/Network/Onboarding/DTO/Request/MajorSearchRequestQueryDTO.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Onboarding/DTO/Request/MajorSearchRequestQueryDTO.swift
@@ -10,6 +10,6 @@ import Foundation
 // MARK: - MajorSearchRequestQueryDTO
 struct MajorSearchRequestQueryDTO: Codable {
     let school: String
-    let search: String
+    let keyword: String
     let page: Int
 }

--- a/YELLO-iOS/YELLO-iOS/Network/Onboarding/DTO/Request/SchoolSearchRequestQueryDTO.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Onboarding/DTO/Request/SchoolSearchRequestQueryDTO.swift
@@ -9,6 +9,6 @@ import Foundation
 
 // MARK: - SchoolSearchRequestDTO
 struct SchoolSearchRequestQueryDTO: Codable {
-    let search: String
+    let keyword: String
     let page: Int
 }

--- a/YELLO-iOS/YELLO-iOS/Network/Onboarding/Router/OnboardingTarget.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Onboarding/Router/OnboardingTarget.swift
@@ -17,6 +17,7 @@ enum OnboardingTarget {
     case postFirendsList( _ query: JoinedFriendsRequestQueryDTO, _ dto: JoinedFriendsRequestDTO) /// 가입한 친구 목록 불러오기
     case postUserInfo(_ dto: SignUpRequestDTO ) /// 회원가입
     case postRefreshToken(_ dto: TokenRefreshRequestDTO)
+    case putDeviceToken(_ dto: DeviceTokenRefreshRequestDTO)
 }
 
 extension OnboardingTarget: TargetType {
@@ -36,6 +37,8 @@ extension OnboardingTarget: TargetType {
             return .unauthorization
         case .postRefreshToken:
             return .unauthorization
+        case .putDeviceToken:
+            return .authorization
         }
     }
     
@@ -55,6 +58,8 @@ extension OnboardingTarget: TargetType {
             return .plain
         case .postRefreshToken:
             return .refreshToken
+        case .putDeviceToken:
+            return .plain
         }
     }
     
@@ -74,6 +79,8 @@ extension OnboardingTarget: TargetType {
             return .post
         case .postRefreshToken:
             return .post
+        case .putDeviceToken:
+            return .put
         }
     }
     
@@ -82,7 +89,7 @@ extension OnboardingTarget: TargetType {
         case .postTokenChange:
             return "/auth/oauth"
         case .getSchoolList:
-            return "/auth/school/school"
+            return "/auth/school"
         case .getCheckDuplicate:
             return "/auth/valid"
         case .postUserInfo:
@@ -93,6 +100,8 @@ extension OnboardingTarget: TargetType {
             return "/auth/friend"
         case .postRefreshToken:
             return "/auth/token/issue"
+        case .putDeviceToken:
+            return "/user/device"
         }
     }
     
@@ -111,6 +120,8 @@ extension OnboardingTarget: TargetType {
         case .postFirendsList(let query, let dto):
             return .requestQueryWithBody(query, bodyParameter: dto)
         case .postRefreshToken(let dto):
+            return .requestWithBody(dto)
+        case .putDeviceToken(let dto):
             return .requestWithBody(dto)
         }
     }

--- a/YELLO-iOS/YELLO-iOS/Network/Onboarding/Service/OnboardingService.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Onboarding/Service/OnboardingService.swift
@@ -16,7 +16,9 @@ protocol OnboardingServiceProtocol {
     func getSchoolList(queryDTO: SchoolSearchRequestQueryDTO, completion: @escaping (NetworkResult<BaseResponse<SchoolSearchResponseDTO>>) -> Void)
     func getMajorList(queryDTO: MajorSearchRequestQueryDTO, completion: @escaping (NetworkResult<BaseResponse<MajorSearchResponseDTO>>) -> Void)
     func postJoinedFriends(queryDTO: JoinedFriendsRequestQueryDTO, requestDTO: JoinedFriendsRequestDTO, completion: @escaping (NetworkResult<BaseResponse<JoinedFriendsResponseDTO>>) -> Void)
-    func postRefreshToken(requsetDTO: TokenRefreshRequestDTO, completion: @escaping (NetworkResult<BaseResponse<TokenRefreshResponseDTO>>)->Void)
+    func postRefreshToken(requsetDTO: TokenRefreshRequestDTO, completion: @escaping (NetworkResult<BaseResponse<TokenRefreshResponseDTO>>) -> Void)
+    func putRefreshDeviceToken(requsetDTO: DeviceTokenRefreshRequestDTO, completion: @escaping (NetworkResult<BaseResponse<String>>) ->Void)
+    
 }
 
 final class OnboardingService: APIRequestLoader<OnboardingTarget>, OnboardingServiceProtocol {
@@ -47,6 +49,10 @@ final class OnboardingService: APIRequestLoader<OnboardingTarget>, OnboardingSer
     
     func postRefreshToken(requsetDTO: TokenRefreshRequestDTO, completion: @escaping (NetworkResult<BaseResponse<TokenRefreshResponseDTO>>)->Void) {
         fetchData(target: .postRefreshToken(requsetDTO), responseData: BaseResponse<TokenRefreshResponseDTO>.self, completion: completion)
+    }
+    
+    func putRefreshDeviceToken(requsetDTO: DeviceTokenRefreshRequestDTO, completion: @escaping (NetworkResult<BaseResponse<String>>)->Void) {
+        fetchData(target: .putDeviceToken(requsetDTO), responseData: BaseResponse.self, completion: completion)
     }
     
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/Modal/FindMajorViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/Modal/FindMajorViewController.swift
@@ -58,7 +58,7 @@ class FindMajorViewController: SearchBaseViewController {
     
     // MARK: Objc Function
     func searchMajor(_ word: String) {
-        let queryDTO: MajorSearchRequestQueryDTO = MajorSearchRequestQueryDTO(school: schoolName, search: word, page: pageCount)
+        let queryDTO: MajorSearchRequestQueryDTO = MajorSearchRequestQueryDTO(school: schoolName, keyword: word, page: pageCount)
         
         NetworkService.shared.onboardingService.getMajorList(queryDTO: queryDTO) { [weak self] result in
             switch result {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/Modal/FindSchoolViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/Modal/FindSchoolViewController.swift
@@ -31,7 +31,7 @@ class FindSchoolViewController: SearchBaseViewController {
     }
     
     func searchSchool(_ word: String) {
-        let queryDTO: SchoolSearchRequestQueryDTO = SchoolSearchRequestQueryDTO(search: word, page: pageCount)
+        let queryDTO: SchoolSearchRequestQueryDTO = SchoolSearchRequestQueryDTO(keyword: word, page: pageCount)
         NetworkService.shared.onboardingService.getSchoolList(queryDTO: queryDTO) { result in
             switch result {
             case .success(let data):


### PR DESCRIPTION
## ⛏ 작업 내용
서버 변경 사항을 적용했습니다. 
- 학교 검색 라우터 변경
- 학과 / 학교 검색 쿼리 DTO 수정
- 디바이스 토큰 재발급 서버 부착


## 📌 PR Point!
- **현 상황**: 디바이스 토큰이 앱이 켜질 때마다 발급 -> 재발급 네트워크 통신 -> 존재하는 디바이스 토큰이므로 409 에러 발생 
- **매번 이걸 Put 해주는 게 맞는지에 대한 고민이 조금 더 필요한 것 같습니다.** FCM 토큰은 따로 재발급 주기가 없어서 아래 상황이 아니면 재발급이 되지 않습니다. 하지만 아래 상황을 감지할 방법이 정확히 존재하지 않아서 일단 가져올 때마다 디바이스 토큰 재발급 로직을 구현해뒀습니다. 
```
 FCM 토큰이 재발급 되는 상황
- 앱이 인스턴스 ID를 삭제한 경우
- 앱이 새 기기에서 복원되었을 경우
- 사용자가 앱을 제거/ 재설치한 경우
- 사용자가 앱 데이터를 지운 경우 
```


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 화면종류 | 없습니다 |


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #230 
