### PR TITLE
Fix [#253] 카카오싱크 로직 변경

### DIFF
--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/Base/OnboardingViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/Base/OnboardingViewController.swift
@@ -31,6 +31,7 @@ class OnboardingBaseViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationController?.interactivePopGestureRecognizer?.isEnabled = false
+        self.navigationController?.navigationBar.isHidden = true
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoLoginViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoLoginViewController.swift
@@ -82,7 +82,7 @@ class KakaoLoginViewController: UIViewController {
                                 /// 확인 후 플로우 변경
                                 let nextViewController = allowList[0].agreed ? UniversityViewController() : KakaoConnectViewController()
                                 let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as! SceneDelegate
-                                self.navigationController?.pushViewController(nextViewController, animated: true)
+                                sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: nextViewController)
                             }
                         }
                         

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoLoginViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoLoginViewController.swift
@@ -80,7 +80,7 @@ class KakaoLoginViewController: UIViewController {
                                 }
                                 
                                 /// 확인 후 플로우 변경
-                                let nextViewController = allowList[0].agreed ? SchoolSelectViewController() : KakaoConnectViewController()
+                                let nextViewController = allowList[0].agreed ? UniversityViewController() : KakaoConnectViewController()
                                 let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as! SceneDelegate
                                 self.navigationController?.pushViewController(nextViewController, animated: true)
                             }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoLoginViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoLoginViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import Amplitude
 import KakaoSDKUser
+import KakaoSDKTalk
 
 class KakaoLoginViewController: UIViewController {
     // MARK: - Variables
@@ -44,24 +45,48 @@ class KakaoLoginViewController: UIViewController {
                             _ = user
                             guard let user = user else { return }
                             guard let uuidInt = user.id else { return }
-                            let uuid = String(uuidInt)
-                            
                             guard let kakaoUser = user.kakaoAccount else {return}
                             guard let email = kakaoUser.email else {return}
                             guard let profile = user.kakaoAccount?.profile?.profileImageUrl else {return}
                             User.shared.social = "KAKAO"
-                            User.shared.uuid = uuid
+                            User.shared.uuid = String(uuidInt)
                             User.shared.email = email
                             User.shared.name = kakaoUser.name ?? ""
                             User.shared.gender = kakaoUser.gender?.rawValue.uppercased() ?? ""
                             User.shared.profileImage = profile.absoluteString
-                            
                         }
+                        
+                        UserApi.shared.scopes(scopes: ["friends"]) { (scopeInfo, error) in
+                            if let error = error {
+                                print(error)
+                            } else {
+                                /// 동의항목 확인하기
+                                guard let scopeInfo = scopeInfo else { return }
+                                guard let allowList = scopeInfo.scopes else { return }
+                                if allowList[0].agreed {
+                                    Amplitude.instance().logEvent("click_onboarding_kakao_friends")
+                                    TalkApi.shared.friends(limit: 100) {(friends, error) in
+                                        if let error = error {
+                                            print(error)
+                                        } else {
+                                            var allFriends: [String] = []
+                                            friends?.elements?.forEach({
+                                                guard let id = $0.id else { return }
+                                                allFriends.append(String(id))
+                                            })
+                                            User.shared.kakaoFriends = allFriends
+                                        }
+                                    }
+                                }
+                                
+                                /// 확인 후 플로우 변경
+                                let nextViewController = allowList[0].agreed ? SchoolSelectViewController() : KakaoConnectViewController()
+                                let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as! SceneDelegate
+                                self.navigationController?.pushViewController(nextViewController, animated: true)
+                            }
+                        }
+                        
                     }
-                    
-                    let kakaoConnectViewController = (KakaoConnectViewController())
-                    let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as! SceneDelegate
-                    self.navigationController?.pushViewController(KakaoConnectViewController(), animated: true)
                 } else if data.status == 201 {
                     guard let data = data.data else { return }
                     KeychainHandler.shared.accessToken = data.accessToken
@@ -109,9 +134,9 @@ class KakaoLoginViewController: UIViewController {
                     print("🚩🚩\(error)")
                 } else {
                     print("----🚩카카오 톡으로 로그인 성공🚩----")
+                    Amplitude.instance().logEvent("complete_onboarding_finish")
                     guard let kakaoToken = oauthToken?.accessToken else { return }
                     let queryDTO = KakaoLoginRequestDTO(accessToken: kakaoToken, social: "KAKAO", deviceToken: User.shared.deviceToken)
-                    
                     self.authNetwork(queryDTO: queryDTO)
                 }
             }
@@ -122,13 +147,13 @@ class KakaoLoginViewController: UIViewController {
                     print(error)
                 } else {
                     print("카카오 계정으로 로그인 성공")
+                    Amplitude.instance().logEvent("complete_onboarding_finish")
                     guard let kakaoToken = oauthToken?.accessToken else { return }
                     let queryDTO = KakaoLoginRequestDTO(accessToken: kakaoToken, social: "KAKAO", deviceToken: User.shared.deviceToken)
                     self.authNetwork(queryDTO: queryDTO)
-                    Amplitude.instance().logEvent("complete_onboarding_finish")
                 }
             }
         }
-        
     }
+    
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/UniversityViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/UniversityViewController.swift
@@ -39,7 +39,7 @@ class UniversityViewController: OnboardingBaseViewController {
     }
     
     override func setLayout() {
-        
+        navigationBarView.backButton.isHidden = true
         view.addSubview(baseView)
         nextViewController = UserInfoViewController()
         baseView.snp.makeConstraints {


### PR DESCRIPTION
## ⛏ 작업 내용
카카오 친구 연결뷰 분기 처리 진행

## 📌 PR Point!
카카오톡 로그인 시 카카오 친구 연결을 하면 `카카오 친구 연결뷰`의 카카오연결에서 외부 링크로 이동하지 않기 때문에 불필요한 뎁스가 생겼습니다. 이 부분을 개선하기 위해 동의 여부로 분기처리를 진행했습니다.
또한 카카오톡이 없는 카카오계정으로 로그인 시 카카오 친구 연결이 되지않도록 처리했습니다. 

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
|친구를 카카오톡 로그인에서 동의하지 않은 상태 |![Simulator Screen Recording - iPhone 14 Pro - 2023-09-19 at 01 58 30](https://github.com/team-yello/YELLO-iOS/assets/68178395/6bafe191-6702-4528-8424-73f12ead33d3) |
|카카오톡 로그인 시 동의한 상태|![Simulator Screen Recording - iPhone 14 Pro - 2023-09-19 at 02 29 53](https://github.com/team-yello/YELLO-iOS/assets/68178395/bcddb787-601f-4952-9c42-5476157c821e)|
|카카오계정(카카오톡 존재X)으로 로그인|![Simulator Screen Recording - iPhone 14 Pro - 2023-09-19 at 02 32 01](https://github.com/team-yello/YELLO-iOS/assets/68178395/6162d3a3-1046-4e8d-a149-bc98c57eab11)|



### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #255 
