### PR TITLE
Fix [#258] 결제 중복 500 에러 해결

### DIFF
--- a/YELLO-iOS/YELLO-iOS/Presentation/Payment/ViewController/PaymentPlusViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Payment/ViewController/PaymentPlusViewController.swift
@@ -256,7 +256,6 @@ extension PaymentPlusViewController {
             verifySubscriptionPurchase(transactionID: transactionID)
             
         }
-        print("여기")
     }
     
     private func verifyConsumablePurchase(transactionID: String, productID: String) {


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- transactionID를 자체 서버 측으로 보내주는 과정에서 무작위로 중복되어 보내지는 경우가 있어 500 에러가 떴는데 해당 부분 정확한 원인을 찾지 못했기 때문에 우선적으로 결제 되는 과정에서 결제 완료 처리된 transactionID가 있는지 유무를 나눠서 분기처리 했습니다. 추후 원인 발견하게 된다면 수정토록 하겠습니다!
<!--
```
작성한 코드가 있다면 여기에 주석을 제거하고 적어주세요!
```
-->


## 📌 PR Point!
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- x


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 화면종류 | x |


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #258 
