### PR TITLE
Feat [#263] 온보딩 수정 사항 반영

### DIFF
--- a/YELLO-iOS/YELLO-iOS/Global/Literals/String.swift
+++ b/YELLO-iOS/YELLO-iOS/Global/Literals/String.swift
@@ -20,6 +20,7 @@ enum StringLiterals {
     }
     
     enum Onboarding {
+        static let privacyButtonText = "개인정보처리방침"
         static let selectHighText = "고등학생"
         static let selectUnivText = "대학생"
         static let selectFemaleText = "여자"

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/HighSchoolViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/HighSchoolViewController.swift
@@ -40,8 +40,8 @@ class HighSchoolViewController: OnboardingBaseViewController {
     
     // MARK: Layout Helpers
     override func setStyle() {
-        studentIdView.studentIdList = (1...10).map { "\($0)반" }
-        studentIdViewController.studentIdList = (1...10).map { "\($0)반" }
+        studentIdView.studentIdList = (1...20).map { "\($0)반" }
+        studentIdViewController.studentIdList = (1...20).map { "\($0)반" }
     }
     
     override func setLayout() {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoConnectViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoConnectViewController.swift
@@ -32,6 +32,7 @@ class KakaoConnectViewController: UIViewController {
     
     func addTarget() {
         baseView.kakaoConnectButton.addTarget(self, action: #selector(connectButtonDidTap), for: .touchUpInside)
+        baseView.privacyButton.addTarget(self, action: #selector(privacyButtonDidTap), for: .touchUpInside)
     }
     
     @objc func connectButtonDidTap() {
@@ -50,6 +51,11 @@ class KakaoConnectViewController: UIViewController {
             }
         }
         
+    }
+    
+    @objc func privacyButtonDidTap() {
+        guard let url = URL(string: "https://yell0.notion.site/97f57eaed6c749bbb134c7e8dc81ab3f") else { return }
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
     }
     
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoLoginViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoLoginViewController.swift
@@ -30,6 +30,7 @@ class KakaoLoginViewController: UIViewController {
     // MARK: Custom Function
     func addTarget() {
         baseView.kakaoButton.addTarget(self, action: #selector(kakaoLoginButtonDidTap), for: .touchUpInside)
+        baseView.privacyButton.addTarget(self, action: #selector(privacyButtonDidTap), for: .touchUpInside)
     }
     
     func authNetwork(queryDTO: KakaoLoginRequestDTO) {
@@ -99,7 +100,7 @@ class KakaoLoginViewController: UIViewController {
                     Amplitude.instance().logEvent("complete_onboarding_finish")
                     
                     let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as! SceneDelegate
-
+                    
                     if isFirstTime() {
                         let rootViewController = PushSettingViewController()
                         sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: rootViewController)
@@ -154,6 +155,11 @@ class KakaoLoginViewController: UIViewController {
                 }
             }
         }
+    }
+    
+    @objc func privacyButtonDidTap() {
+        guard let url = URL(string: "https://yell0.notion.site/97f57eaed6c749bbb134c7e8dc81ab3f") else { return }
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
     }
     
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/SchoolSelectViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/SchoolSelectViewController.swift
@@ -35,6 +35,8 @@ class SchoolSelectViewController: OnboardingBaseViewController {
     private func addTarget() {
         baseView.highSchoolButton.addTarget(self, action: #selector(setSchoolLevel(sender:)), for: .touchUpInside)
         baseView.univButton.addTarget(self, action: #selector(setSchoolLevel(sender:)), for: .touchUpInside)
+        baseView.highSchoolButton.checkButton.addTarget(self, action: #selector(setSchoolLevel(sender: )), for: .touchUpInside)
+        baseView.univButton.checkButton.addTarget(self, action: #selector(setSchoolLevel(sender: )), for: .touchUpInside)
     }
     
     @objc func setSchoolLevel(sender: YelloSelectButton) {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/KakaoConnectView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/KakaoConnectView.swift
@@ -13,6 +13,7 @@ final class KakaoConnectView: BaseView {
     let subTitleLabel = UILabel()
     let imageView = UIImageView()
     let kakaoConnectButton = UIButton()
+    let privacyButton = UIButton()
     
     let stackView = UIStackView()
     
@@ -53,6 +54,14 @@ final class KakaoConnectView: BaseView {
             $0.makeCornerRound(radius: 8)
         }
         
+        privacyButton.do {
+            $0.setImage(ImageLiterals.OnBoarding.icAlertCircle, for: .normal)
+            $0.setTitle("개인정보처리방침", for: .normal)
+            $0.setTitleColor(.grayscales500, for: .normal)
+            $0.titleLabel?.font = .uiLabelLarge
+            $0.setUnderline()
+            $0.imageEdgeInsets = UIEdgeInsets(top: 0, left: -2, bottom: 0, right: 0)
+        }
     }
     
     override func setLayout() {
@@ -60,7 +69,8 @@ final class KakaoConnectView: BaseView {
         self.addSubviews(titleLabel,
                          subTitleLabel,
                          imageView,
-                         kakaoConnectButton)
+                         kakaoConnectButton,
+                        privacyButton)
         
         titleLabel.snp.makeConstraints {
             $0.bottom.equalTo(subTitleLabel.snp.top).offset(-8.adjustedHeight)
@@ -80,6 +90,11 @@ final class KakaoConnectView: BaseView {
             $0.height.equalTo(48.adjustedHeight)
             $0.bottom.equalToSuperview().inset(91.adjustedHeight)
             $0.leading.trailing.equalToSuperview().inset(16.adjustedWidth)
+        }
+        
+        privacyButton.snp.makeConstraints {
+            $0.top.equalTo(kakaoConnectButton.snp.bottom).offset(18)
+            $0.centerX.equalToSuperview()
         }
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/KakaoConnectView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/KakaoConnectView.swift
@@ -93,7 +93,7 @@ final class KakaoConnectView: BaseView {
         }
         
         privacyButton.snp.makeConstraints {
-            $0.top.equalTo(kakaoConnectButton.snp.bottom).offset(18)
+            $0.top.equalTo(kakaoConnectButton.snp.bottom).offset(18.adjustedHeight)
             $0.centerX.equalToSuperview()
         }
     }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/KakaoConnectView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/KakaoConnectView.swift
@@ -56,7 +56,7 @@ final class KakaoConnectView: BaseView {
         
         privacyButton.do {
             $0.setImage(ImageLiterals.OnBoarding.icAlertCircle, for: .normal)
-            $0.setTitle("개인정보처리방침", for: .normal)
+            $0.setTitle(StringLiterals.Onboarding.privacyButtonText, for: .normal)
             $0.setTitleColor(.grayscales500, for: .normal)
             $0.titleLabel?.font = .uiLabelLarge
             $0.setUnderline()

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/KakaoLoginView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/KakaoLoginView.swift
@@ -98,7 +98,7 @@ class KakaoLoginView: BaseView {
         })
         
         privacyButton.snp.makeConstraints {
-            $0.top.equalTo(kakaoButton.snp.bottom).offset(18)
+            $0.top.equalTo(kakaoButton.snp.bottom).offset(18.adjustedHeight)
             $0.centerX.equalToSuperview()
         }
      

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/KakaoLoginView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/KakaoLoginView.swift
@@ -56,7 +56,7 @@ class KakaoLoginView: BaseView {
         
         privacyButton.do {
             $0.setImage(ImageLiterals.OnBoarding.icAlertCircle, for: .normal)
-            $0.setTitle("개인정보처리방침", for: .normal)
+            $0.setTitle(StringLiterals.Onboarding.privacyButtonText, for: .normal)
             $0.setTitleColor(.grayscales500, for: .normal)
             $0.titleLabel?.font = .uiLabelLarge
             $0.setUnderline()

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/KakaoLoginView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/View/KakaoLoginView.swift
@@ -13,6 +13,7 @@ class KakaoLoginView: BaseView {
     let subTitleLabel = UILabel()
     let imageView = UIImageView()
     let kakaoButton = UIButton()
+    let privacyButton = UIButton()
     
     let stackView = UIStackView()
     
@@ -52,6 +53,15 @@ class KakaoLoginView: BaseView {
             $0.setImage(ImageLiterals.OnBoarding.icKakao, for: .normal)
             $0.makeCornerRound(radius: 8.adjusted)
         }
+        
+        privacyButton.do {
+            $0.setImage(ImageLiterals.OnBoarding.icAlertCircle, for: .normal)
+            $0.setTitle("개인정보처리방침", for: .normal)
+            $0.setTitleColor(.grayscales500, for: .normal)
+            $0.titleLabel?.font = .uiLabelLarge
+            $0.setUnderline()
+            $0.imageEdgeInsets = UIEdgeInsets(top: 0, left: -2, bottom: 0, right: 0)
+        }
     }
     
     override func setLayout() {
@@ -59,7 +69,8 @@ class KakaoLoginView: BaseView {
         self.addSubviews(titleLabel,
                          subTitleLabel,
                          imageView,
-                         kakaoButton)
+                         kakaoButton,
+                         privacyButton)
         
         titleLabel.snp.makeConstraints {
             $0.bottom.equalTo(subTitleLabel.snp.top).offset(-8.adjustedHeight)
@@ -85,6 +96,11 @@ class KakaoLoginView: BaseView {
             $0.leading.equalToSuperview().offset(28.adjustedHeight)
             $0.centerY.equalToSuperview()
         })
+        
+        privacyButton.snp.makeConstraints {
+            $0.top.equalTo(kakaoButton.snp.bottom).offset(18)
+            $0.centerX.equalToSuperview()
+        }
      
     }
 }


### PR DESCRIPTION
## ⛏ 작업 내용
- 학반 범위를 20반까지 확대했습니다. 
- 카카오 친구 연결 뷰와 카카오톡 로그인 부분에 '개인정보처리방침'버튼을 추가했습니다. 

## 📌 PR Point!
- 없습니다.


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 카카오로그인 | ![Simulator Screen Recording - iPhone 14 Pro - 2023-10-03 at 15 23 09](https://github.com/team-yello/YELLO-iOS/assets/68178395/1d2ac521-d539-4bb6-baeb-4a618db18571) |
|고등학교 반 범위|![Simulator Screen Recording - iPhone 14 Pro - 2023-10-03 at 15 23 33](https://github.com/team-yello/YELLO-iOS/assets/68178395/f98b91da-64a0-4cd5-9bb9-e4644495b1db)|



### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #263 
