### PR TITLE
Feat [#266] Firebase Crashlytics 연결

### DIFF
--- a/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
+++ b/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
@@ -36,8 +36,6 @@
 		2A8D66D22A97C5AE009DEC3F /* NetworkCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A8D66D12A97C5AE009DEC3F /* NetworkCheck.swift */; };
 		2A8D66D92A9A363A009DEC3F /* SubscriptionExtensionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A8D66D82A9A363A009DEC3F /* SubscriptionExtensionView.swift */; };
 		2A9808E92A81658500FBA5B3 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2A9808E82A81658500FBA5B3 /* GoogleService-Info.plist */; };
-		2A9808EF2A81806500FBA5B3 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 2A9808EE2A81806500FBA5B3 /* FirebaseAnalytics */; };
-		2A9808F12A81806500FBA5B3 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 2A9808F02A81806500FBA5B3 /* FirebaseMessaging */; };
 		2AA0DBB02A546E1D002B1370 /* RecommendingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AA0DBAF2A546E1D002B1370 /* RecommendingViewController.swift */; };
 		2AA0DBB22A546E4B002B1370 /* AroundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AA0DBB12A546E4B002B1370 /* AroundViewController.swift */; };
 		2AA0DBB42A546E62002B1370 /* VotingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AA0DBB32A546E62002B1370 /* VotingViewController.swift */; };
@@ -147,6 +145,33 @@
 		36E427932A5C9BE30050B34E /* RecommendIdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E427922A5C9BE30050B34E /* RecommendIdView.swift */; };
 		36E427952A5CA59F0050B34E /* OnboardingEndViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E427942A5CA59F0050B34E /* OnboardingEndViewController.swift */; };
 		36E427972A5CA5AF0050B34E /* OnboardingEndView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E427962A5CA5AF0050B34E /* OnboardingEndView.swift */; };
+		36E60E912AE6DFC4005035D3 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60E902AE6DFC4005035D3 /* FirebaseAnalytics */; };
+		36E60E932AE6DFC4005035D3 /* FirebaseAnalyticsOnDeviceConversion in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60E922AE6DFC4005035D3 /* FirebaseAnalyticsOnDeviceConversion */; };
+		36E60E952AE6DFC4005035D3 /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60E942AE6DFC4005035D3 /* FirebaseAnalyticsSwift */; };
+		36E60E972AE6DFC4005035D3 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60E962AE6DFC4005035D3 /* FirebaseAnalyticsWithoutAdIdSupport */; };
+		36E60E992AE6DFC4005035D3 /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60E982AE6DFC4005035D3 /* FirebaseAppCheck */; };
+		36E60E9B2AE6DFC4005035D3 /* FirebaseAppDistribution-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60E9A2AE6DFC4005035D3 /* FirebaseAppDistribution-Beta */; };
+		36E60E9D2AE6DFC4005035D3 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60E9C2AE6DFC4005035D3 /* FirebaseAuth */; };
+		36E60E9F2AE6DFC4005035D3 /* FirebaseAuthCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60E9E2AE6DFC4005035D3 /* FirebaseAuthCombine-Community */; };
+		36E60EA12AE6DFC4005035D3 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EA02AE6DFC4005035D3 /* FirebaseCrashlytics */; };
+		36E60EA32AE6DFC4005035D3 /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EA22AE6DFC4005035D3 /* FirebaseDatabase */; };
+		36E60EA52AE6DFC4005035D3 /* FirebaseDatabaseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EA42AE6DFC4005035D3 /* FirebaseDatabaseSwift */; };
+		36E60EA72AE6DFC4005035D3 /* FirebaseDynamicLinks in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EA62AE6DFC4005035D3 /* FirebaseDynamicLinks */; };
+		36E60EA92AE6DFC4005035D3 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EA82AE6DFC4005035D3 /* FirebaseFirestore */; };
+		36E60EAB2AE6DFC4005035D3 /* FirebaseFirestoreCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EAA2AE6DFC4005035D3 /* FirebaseFirestoreCombine-Community */; };
+		36E60EAD2AE6DFC4005035D3 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EAC2AE6DFC4005035D3 /* FirebaseFirestoreSwift */; };
+		36E60EAF2AE6DFC4005035D3 /* FirebaseFunctions in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EAE2AE6DFC4005035D3 /* FirebaseFunctions */; };
+		36E60EB12AE6DFC4005035D3 /* FirebaseFunctionsCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EB02AE6DFC4005035D3 /* FirebaseFunctionsCombine-Community */; };
+		36E60EB32AE6DFC4005035D3 /* FirebaseInAppMessaging-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EB22AE6DFC4005035D3 /* FirebaseInAppMessaging-Beta */; };
+		36E60EB52AE6DFC4005035D3 /* FirebaseInAppMessagingSwift-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EB42AE6DFC4005035D3 /* FirebaseInAppMessagingSwift-Beta */; };
+		36E60EB72AE6DFC4005035D3 /* FirebaseInstallations in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EB62AE6DFC4005035D3 /* FirebaseInstallations */; };
+		36E60EB92AE6DFC4005035D3 /* FirebaseMLModelDownloader in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EB82AE6DFC4005035D3 /* FirebaseMLModelDownloader */; };
+		36E60EBB2AE6DFC4005035D3 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EBA2AE6DFC4005035D3 /* FirebaseMessaging */; };
+		36E60EBD2AE6DFC4005035D3 /* FirebasePerformance in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EBC2AE6DFC4005035D3 /* FirebasePerformance */; };
+		36E60EBF2AE6DFC4005035D3 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EBE2AE6DFC4005035D3 /* FirebaseRemoteConfig */; };
+		36E60EC12AE6DFC4005035D3 /* FirebaseRemoteConfigSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EC02AE6DFC4005035D3 /* FirebaseRemoteConfigSwift */; };
+		36E60EC32AE6DFC4005035D3 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EC22AE6DFC4005035D3 /* FirebaseStorage */; };
+		36E60EC52AE6DFC4005035D3 /* FirebaseStorageCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EC42AE6DFC4005035D3 /* FirebaseStorageCombine-Community */; };
 		36EA2AB72A66FC0B003603C7 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36EA2AB62A66FC0B003603C7 /* User.swift */; };
 		C305A5B22A85F997007C4A69 /* PaymentConfirmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C305A5B12A85F997007C4A69 /* PaymentConfirmView.swift */; };
 		C306E7272A630BB70031514C /* KeychainHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C306E7262A630BB70031514C /* KeychainHandler.swift */; };
@@ -600,17 +625,42 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2A9808F12A81806500FBA5B3 /* FirebaseMessaging in Frameworks */,
+				36E60EBF2AE6DFC4005035D3 /* FirebaseRemoteConfig in Frameworks */,
+				36E60EBB2AE6DFC4005035D3 /* FirebaseMessaging in Frameworks */,
+				36E60EA52AE6DFC4005035D3 /* FirebaseDatabaseSwift in Frameworks */,
+				36E60E972AE6DFC4005035D3 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */,
+				36E60EB52AE6DFC4005035D3 /* FirebaseInAppMessagingSwift-Beta in Frameworks */,
+				36E60EB32AE6DFC4005035D3 /* FirebaseInAppMessaging-Beta in Frameworks */,
+				36E60E952AE6DFC4005035D3 /* FirebaseAnalyticsSwift in Frameworks */,
+				36E60EBD2AE6DFC4005035D3 /* FirebasePerformance in Frameworks */,
+				36E60E9B2AE6DFC4005035D3 /* FirebaseAppDistribution-Beta in Frameworks */,
+				36E60EC12AE6DFC4005035D3 /* FirebaseRemoteConfigSwift in Frameworks */,
+				36E60E9F2AE6DFC4005035D3 /* FirebaseAuthCombine-Community in Frameworks */,
+				36E60EA72AE6DFC4005035D3 /* FirebaseDynamicLinks in Frameworks */,
 				C3A799B82A4949C600D3EFD8 /* KakaoSDK in Frameworks */,
-				2A9808EF2A81806500FBA5B3 /* FirebaseAnalytics in Frameworks */,
 				2A4C549D2A8622B200FFDF80 /* Kingfisher in Frameworks */,
+				36E60E992AE6DFC4005035D3 /* FirebaseAppCheck in Frameworks */,
+				36E60EB72AE6DFC4005035D3 /* FirebaseInstallations in Frameworks */,
+				36E60EA92AE6DFC4005035D3 /* FirebaseFirestore in Frameworks */,
+				36E60E932AE6DFC4005035D3 /* FirebaseAnalyticsOnDeviceConversion in Frameworks */,
+				36E60EC32AE6DFC4005035D3 /* FirebaseStorage in Frameworks */,
 				C3A799B22A4949A700D3EFD8 /* Alamofire in Frameworks */,
 				C3A799AC2A49499500D3EFD8 /* Then in Frameworks */,
 				C3A799AF2A49499F00D3EFD8 /* SnapKit in Frameworks */,
+				36E60EAB2AE6DFC4005035D3 /* FirebaseFirestoreCombine-Community in Frameworks */,
 				C3C560C92A8BB7E50074E988 /* StoreKit.framework in Frameworks */,
 				2ADE23AA2A5EB7660088FCB3 /* Lottie in Frameworks */,
+				36E60EAF2AE6DFC4005035D3 /* FirebaseFunctions in Frameworks */,
 				36A3B26F2A8D233600BA7CE0 /* Amplitude in Frameworks */,
+				36E60E912AE6DFC4005035D3 /* FirebaseAnalytics in Frameworks */,
+				36E60EA12AE6DFC4005035D3 /* FirebaseCrashlytics in Frameworks */,
+				36E60EB12AE6DFC4005035D3 /* FirebaseFunctionsCombine-Community in Frameworks */,
+				36E60EA32AE6DFC4005035D3 /* FirebaseDatabase in Frameworks */,
 				C306E72A2A630BD10031514C /* SwiftKeychainWrapper in Frameworks */,
+				36E60EB92AE6DFC4005035D3 /* FirebaseMLModelDownloader in Frameworks */,
+				36E60E9D2AE6DFC4005035D3 /* FirebaseAuth in Frameworks */,
+				36E60EC52AE6DFC4005035D3 /* FirebaseStorageCombine-Community in Frameworks */,
+				36E60EAD2AE6DFC4005035D3 /* FirebaseFirestoreSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1930,7 +1980,8 @@
 				C3A7998F2A49490A00D3EFD8 /* Sources */,
 				C3A799902A49490A00D3EFD8 /* Frameworks */,
 				C3A799912A49490A00D3EFD8 /* Resources */,
-				C3A79A092A4951BE00D3EFD8 /* ShellScript */,
+				C3A79A092A4951BE00D3EFD8 /* Run Script */,
+				36E60E8E2AE6CF20005035D3 /* Firebase Crashlytics */,
 			);
 			buildRules = (
 			);
@@ -1944,10 +1995,35 @@
 				C3A799B72A4949C600D3EFD8 /* KakaoSDK */,
 				2ADE23A92A5EB7660088FCB3 /* Lottie */,
 				C306E7292A630BD10031514C /* SwiftKeychainWrapper */,
-				2A9808EE2A81806500FBA5B3 /* FirebaseAnalytics */,
-				2A9808F02A81806500FBA5B3 /* FirebaseMessaging */,
 				2A4C549C2A8622B200FFDF80 /* Kingfisher */,
 				36A3B26E2A8D233600BA7CE0 /* Amplitude */,
+				36E60E902AE6DFC4005035D3 /* FirebaseAnalytics */,
+				36E60E922AE6DFC4005035D3 /* FirebaseAnalyticsOnDeviceConversion */,
+				36E60E942AE6DFC4005035D3 /* FirebaseAnalyticsSwift */,
+				36E60E962AE6DFC4005035D3 /* FirebaseAnalyticsWithoutAdIdSupport */,
+				36E60E982AE6DFC4005035D3 /* FirebaseAppCheck */,
+				36E60E9A2AE6DFC4005035D3 /* FirebaseAppDistribution-Beta */,
+				36E60E9C2AE6DFC4005035D3 /* FirebaseAuth */,
+				36E60E9E2AE6DFC4005035D3 /* FirebaseAuthCombine-Community */,
+				36E60EA02AE6DFC4005035D3 /* FirebaseCrashlytics */,
+				36E60EA22AE6DFC4005035D3 /* FirebaseDatabase */,
+				36E60EA42AE6DFC4005035D3 /* FirebaseDatabaseSwift */,
+				36E60EA62AE6DFC4005035D3 /* FirebaseDynamicLinks */,
+				36E60EA82AE6DFC4005035D3 /* FirebaseFirestore */,
+				36E60EAA2AE6DFC4005035D3 /* FirebaseFirestoreCombine-Community */,
+				36E60EAC2AE6DFC4005035D3 /* FirebaseFirestoreSwift */,
+				36E60EAE2AE6DFC4005035D3 /* FirebaseFunctions */,
+				36E60EB02AE6DFC4005035D3 /* FirebaseFunctionsCombine-Community */,
+				36E60EB22AE6DFC4005035D3 /* FirebaseInAppMessaging-Beta */,
+				36E60EB42AE6DFC4005035D3 /* FirebaseInAppMessagingSwift-Beta */,
+				36E60EB62AE6DFC4005035D3 /* FirebaseInstallations */,
+				36E60EB82AE6DFC4005035D3 /* FirebaseMLModelDownloader */,
+				36E60EBA2AE6DFC4005035D3 /* FirebaseMessaging */,
+				36E60EBC2AE6DFC4005035D3 /* FirebasePerformance */,
+				36E60EBE2AE6DFC4005035D3 /* FirebaseRemoteConfig */,
+				36E60EC02AE6DFC4005035D3 /* FirebaseRemoteConfigSwift */,
+				36E60EC22AE6DFC4005035D3 /* FirebaseStorage */,
+				36E60EC42AE6DFC4005035D3 /* FirebaseStorageCombine-Community */,
 			);
 			productName = "YELLO-iOS";
 			productReference = C3A799932A49490A00D3EFD8 /* YELLO-iOS.app */;
@@ -1984,9 +2060,9 @@
 				C3A799B62A4949C600D3EFD8 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 				2ADE23A82A5EB7660088FCB3 /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				C306E7282A630BD10031514C /* XCRemoteSwiftPackageReference "SwiftKeychainWrapper" */,
-				2A9808ED2A81806500FBA5B3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				2A4C549B2A8622B200FFDF80 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				36A3B26D2A8D233600BA7CE0 /* XCRemoteSwiftPackageReference "Amplitude-iOS" */,
+				36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = C3A799942A49490A00D3EFD8 /* Products */;
 			projectDirPath = "";
@@ -2037,7 +2113,30 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		C3A79A092A4951BE00D3EFD8 /* ShellScript */ = {
+		36E60E8E2AE6CF20005035D3 /* Firebase Crashlytics */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
+			);
+			name = "Firebase Crashlytics";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\n\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n";
+		};
+		C3A79A092A4951BE00D3EFD8 /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2046,6 +2145,7 @@
 			);
 			inputPaths = (
 			);
+			name = "Run Script";
 			outputFileListPaths = (
 			);
 			outputPaths = (
@@ -2408,6 +2508,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 6H688X3AHM;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "YELLO-iOS/Info.plist";
@@ -2423,6 +2524,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.9.0;
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = YELLO.iOS.dev;
 				PRODUCT_NAME = "$(Yello_Bundle_Name)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2569,6 +2671,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 6H688X3AHM;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "YELLO-iOS/Info.plist";
@@ -2584,6 +2687,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.9.0;
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = YELLO.iOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2624,6 +2728,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.9.0;
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = YELLO.iOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2672,14 +2777,6 @@
 				minimumVersion = 7.0.0;
 			};
 		};
-		2A9808ED2A81806500FBA5B3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 9.0.0;
-			};
-		};
 		2ADE23A82A5EB7660088FCB3 /* XCRemoteSwiftPackageReference "lottie-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/airbnb/lottie-ios.git";
@@ -2694,6 +2791,14 @@
 			requirement = {
 				branch = main;
 				kind = branch;
+			};
+		};
+		36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 10.0.0;
 			};
 		};
 		C306E7282A630BD10031514C /* XCRemoteSwiftPackageReference "SwiftKeychainWrapper" */ = {
@@ -2744,16 +2849,6 @@
 			package = 2A4C549B2A8622B200FFDF80 /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
 		};
-		2A9808EE2A81806500FBA5B3 /* FirebaseAnalytics */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2A9808ED2A81806500FBA5B3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseAnalytics;
-		};
-		2A9808F02A81806500FBA5B3 /* FirebaseMessaging */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2A9808ED2A81806500FBA5B3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseMessaging;
-		};
 		2ADE23A92A5EB7660088FCB3 /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 2ADE23A82A5EB7660088FCB3 /* XCRemoteSwiftPackageReference "lottie-ios" */;
@@ -2763,6 +2858,141 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 36A3B26D2A8D233600BA7CE0 /* XCRemoteSwiftPackageReference "Amplitude-iOS" */;
 			productName = Amplitude;
+		};
+		36E60E902AE6DFC4005035D3 /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
+		};
+		36E60E922AE6DFC4005035D3 /* FirebaseAnalyticsOnDeviceConversion */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsOnDeviceConversion;
+		};
+		36E60E942AE6DFC4005035D3 /* FirebaseAnalyticsSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsSwift;
+		};
+		36E60E962AE6DFC4005035D3 /* FirebaseAnalyticsWithoutAdIdSupport */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsWithoutAdIdSupport;
+		};
+		36E60E982AE6DFC4005035D3 /* FirebaseAppCheck */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAppCheck;
+		};
+		36E60E9A2AE6DFC4005035D3 /* FirebaseAppDistribution-Beta */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseAppDistribution-Beta";
+		};
+		36E60E9C2AE6DFC4005035D3 /* FirebaseAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAuth;
+		};
+		36E60E9E2AE6DFC4005035D3 /* FirebaseAuthCombine-Community */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseAuthCombine-Community";
+		};
+		36E60EA02AE6DFC4005035D3 /* FirebaseCrashlytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCrashlytics;
+		};
+		36E60EA22AE6DFC4005035D3 /* FirebaseDatabase */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseDatabase;
+		};
+		36E60EA42AE6DFC4005035D3 /* FirebaseDatabaseSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseDatabaseSwift;
+		};
+		36E60EA62AE6DFC4005035D3 /* FirebaseDynamicLinks */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseDynamicLinks;
+		};
+		36E60EA82AE6DFC4005035D3 /* FirebaseFirestore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFirestore;
+		};
+		36E60EAA2AE6DFC4005035D3 /* FirebaseFirestoreCombine-Community */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseFirestoreCombine-Community";
+		};
+		36E60EAC2AE6DFC4005035D3 /* FirebaseFirestoreSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFirestoreSwift;
+		};
+		36E60EAE2AE6DFC4005035D3 /* FirebaseFunctions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFunctions;
+		};
+		36E60EB02AE6DFC4005035D3 /* FirebaseFunctionsCombine-Community */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseFunctionsCombine-Community";
+		};
+		36E60EB22AE6DFC4005035D3 /* FirebaseInAppMessaging-Beta */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseInAppMessaging-Beta";
+		};
+		36E60EB42AE6DFC4005035D3 /* FirebaseInAppMessagingSwift-Beta */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseInAppMessagingSwift-Beta";
+		};
+		36E60EB62AE6DFC4005035D3 /* FirebaseInstallations */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseInstallations;
+		};
+		36E60EB82AE6DFC4005035D3 /* FirebaseMLModelDownloader */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMLModelDownloader;
+		};
+		36E60EBA2AE6DFC4005035D3 /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
+		};
+		36E60EBC2AE6DFC4005035D3 /* FirebasePerformance */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebasePerformance;
+		};
+		36E60EBE2AE6DFC4005035D3 /* FirebaseRemoteConfig */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseRemoteConfig;
+		};
+		36E60EC02AE6DFC4005035D3 /* FirebaseRemoteConfigSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseRemoteConfigSwift;
+		};
+		36E60EC22AE6DFC4005035D3 /* FirebaseStorage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseStorage;
+		};
+		36E60EC42AE6DFC4005035D3 /* FirebaseStorageCombine-Community */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36E60E8F2AE6DFC4005035D3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseStorageCombine-Community";
 		};
 		C306E7292A630BD10031514C /* SwiftKeychainWrapper */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/YELLO-iOS/YELLO-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/YELLO-iOS/YELLO-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "abseil-cpp-swiftpm",
+      "identity" : "abseil-cpp-binary",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/abseil-cpp-SwiftPM.git",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
       "state" : {
-        "revision" : "583de9bd60f66b40e78d08599cc92036c2e7e4e1",
-        "version" : "0.20220203.2"
+        "revision" : "bfc0b6f81adc06ce5121eb23f628473638d67c5c",
+        "version" : "1.2022062300.0"
       }
     },
     {
@@ -37,21 +37,12 @@
       }
     },
     {
-      "identity" : "boringssl-swiftpm",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/boringssl-SwiftPM.git",
-      "state" : {
-        "revision" : "dd3eda2b05a3f459fc3073695ad1b28659066eab",
-        "version" : "0.9.1"
-      }
-    },
-    {
       "identity" : "firebase-ios-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "7e80c25b51c2ffa238879b07fbfc5baa54bb3050",
-        "version" : "9.6.0"
+        "revision" : "837d4af6ead57cec1fc38007892500d3139c7556",
+        "version" : "10.16.0"
       }
     },
     {
@@ -59,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "c1cfde8067668027b23a42c29d11c246152fe046",
-        "version" : "9.6.0"
+        "revision" : "56f681586ff006a7982b53dc94082eea31971acf",
+        "version" : "10.16.0"
       }
     },
     {
@@ -82,12 +73,12 @@
       }
     },
     {
-      "identity" : "grpc-ios",
+      "identity" : "grpc-binary",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/grpc/grpc-ios.git",
+      "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "8440b914756e0d26d4f4d054a1c1581daedfc5b6",
-        "version" : "1.44.3-grpc"
+        "revision" : "a673bc2937fbe886dd1f99c401b01b6d977a9c98",
+        "version" : "1.49.1"
       }
     },
     {
@@ -97,6 +88,15 @@
       "state" : {
         "revision" : "5ccda3981422a84186387dbb763ba739178b529c",
         "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version" : "100.0.0"
       }
     },
     {

--- a/YELLO-iOS/YELLO-iOS.xcodeproj/xcshareddata/xcschemes/YELLO-iOS.xcscheme
+++ b/YELLO-iOS/YELLO-iOS.xcodeproj/xcshareddata/xcschemes/YELLO-iOS.xcscheme
@@ -49,6 +49,12 @@
             ReferencedContainer = "container:YELLO-iOS.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-FIRDebugEnabled"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/YELLO-iOS/YELLO-iOS/Application/AppDelegate.swift
+++ b/YELLO-iOS/YELLO-iOS/Application/AppDelegate.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import Amplitude
+import Firebase
 import FirebaseCore
 import FirebaseMessaging
 import KakaoSDKCommon


### PR DESCRIPTION
## ⛏ 작업 내용
- Firebase에서 제공하는 충돌 관리툴인 Crashlytics을 연동했습니다. 


## 📌 PR Point!
![image](https://github.com/team-yello/YELLO-iOS/assets/68178395/44d5fbd2-edc3-4c2d-b932-f778d770228a)
- firebase 콘솔에서 충돌 구간을 확인 가능합니다. 
- GA 연결이 필요해서 함께 연결해뒀습니다. 앞으로 firebase 콘솔에서 iOS 데이터도 함께 볼 수 있습니다!

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| firebase 연동 | 없습니다. |


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #266
