### PR TITLE
Fix [#287] 회원가입 오류 HotFix

### DIFF
--- a/YELLO-iOS/YELLO-iOS/Global/Shared/UserManager.swift
+++ b/YELLO-iOS/YELLO-iOS/Global/Shared/UserManager.swift
@@ -10,16 +10,16 @@ import Foundation
 struct UserManager {
     static var shared = UserManager()
     
-    var social: String = ""
+    var social: String = "KAKAO"
     var uuid: String = ""
     var email: String = ""
     var deviceToken: String = ""
     var profileImage: String = ""
-    var groupId: Int = 0
+    var groupId: Int = 1
     var groupAdmissionYear: Int = 0
     var name: String = ""
     var yelloId: String = ""
-    var gender: String = ""
+    var gender: String = "FEMALE"
     var friends: [Int] = []
     var kakaoFriends: [String] = []
     var recommendId: String = ""

--- a/YELLO-iOS/YELLO-iOS/Global/Shared/UserManager.swift
+++ b/YELLO-iOS/YELLO-iOS/Global/Shared/UserManager.swift
@@ -19,7 +19,7 @@ struct UserManager {
     var groupAdmissionYear: Int = 0
     var name: String = ""
     var yelloId: String = ""
-    var gender: String = "FEMALE"
+    var gender: String = ""
     var friends: [Int] = []
     var kakaoFriends: [String] = []
     var recommendId: String = ""

--- a/YELLO-iOS/YELLO-iOS/Network/Base/YelloRequestInterceptor.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Base/YelloRequestInterceptor.swift
@@ -63,7 +63,6 @@ final class YelloRequestInterceptor: RequestInterceptor {
             switch result {
             case .success(let data):
                 if data.status == 403 {
-                    completion(false)
                     self.logout()
                 }
                 if data.status == 201 {
@@ -89,15 +88,15 @@ final class YelloRequestInterceptor: RequestInterceptor {
             } else {
                 DispatchQueue.main.async {
                     print("logout() success.")
-                    let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as! SceneDelegate
-                    
-                    UserManager.shared.isResigned = false
-                    UserManager.shared.isFirstUser = false
-                    
-                    UserDefaults.standard.removeObject(forKey: "isLoggined")
-                    sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: KakaoLoginViewController())
                 }
             }
         }
+        let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as! SceneDelegate
+        
+        UserManager.shared.isResigned = false
+        UserManager.shared.isFirstUser = false
+        
+        UserDefaults.standard.removeObject(forKey: "isLoggined")
+        sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: KakaoLoginViewController())
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/HighSchoolViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/HighSchoolViewController.swift
@@ -139,8 +139,6 @@ class HighSchoolViewController: OnboardingBaseViewController {
         guard let buttonTitleLabel = sender.titleLabel else { return }
         self.schoolLevel = extractNumbers(from: buttonTitleLabel.text ?? "")
     }
-
-    
 }
 
 extension HighSchoolViewController: UITextFieldDelegate {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoLoginViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoLoginViewController.swift
@@ -54,7 +54,9 @@ class KakaoLoginViewController: UIViewController {
                                         } else {
                                             UserManager.shared.isNeedModName = true
                                         }
-                                        UserManager.shared.gender = kakaoUser.gender?.rawValue.uppercased() ?? ""
+                                        if let gender = kakaoUser.gender {
+                                            UserManager.shared.gender = gender.rawValue.uppercased()
+                                        }
                                         if let profile = kakaoUser.profile?.profileImageUrl {
                                             UserManager.shared.profileImage = profile.absoluteString
                                         }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/RecommendIdViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/RecommendIdViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import Amplitude
+import FirebaseCrashlytics
 
 class RecommendIdViewController: OnboardingBaseViewController {
     // MARK: - Variables
@@ -144,6 +145,12 @@ class RecommendIdViewController: OnboardingBaseViewController {
                 Amplitude.instance().setUserProperties(userProperties)
                 self.didPostUserInfo = true
                 self.navigationController?.pushViewController(pushViewController, animated: false)
+            case .requestErr(let data):
+                self.isFail = true
+                self.view.showToast(message: "오류가 발생했습니다. 잠시후 다시 시도해주세요.")
+                Crashlytics.crashlytics().setUserID(UserManager.shared.yelloId)
+                Crashlytics.crashlytics().log("dto: \(requestDTO) \n message: \(data.message)")
+                return
             default:
                 self.isFail = true
                 self.view.showToast(message: "알 수 없는 오류가 발생하였습니다.")

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/RecommendIdViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/RecommendIdViewController.swift
@@ -110,6 +110,12 @@ class RecommendIdViewController: OnboardingBaseViewController {
     
     private func postUserInfo() {
         let user = UserManager.shared
+        
+        if user.gender == "" {
+            UserManager.shared.gender = "FEMALE"
+            Crashlytics.crashlytics().log("성별값이 올바르지 않습니다. 기본값으로 설정합니다.")
+        }
+        
         let requestDTO = SignUpRequestDTO(social: user.social, uuid: user.uuid, deviceToken: user.deviceToken, email: user.email, profileImage: user.profileImage, groupID: user.groupId, groupAdmissionYear: user.groupAdmissionYear, name: user.name, yelloID: user.yelloId, gender: user.gender, friends: user.friends, recommendID: user.recommendId)
         
         NetworkService.shared.onboardingService.postUserInfo(requestDTO: requestDTO) { [self] result in

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/RecommendIdViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/RecommendIdViewController.swift
@@ -153,8 +153,9 @@ class RecommendIdViewController: OnboardingBaseViewController {
     }
     
     override func setUser() {
-        guard let text = baseView.recommendIdTextField.textField.text else { return }
-        UserManager.shared.recommendId = text
+        if let text = baseView.recommendIdTextField.textField.text {
+            UserManager.shared.recommendId = text
+        }
     }
     
     // MARK: Objc Function
@@ -170,21 +171,21 @@ class RecommendIdViewController: OnboardingBaseViewController {
     }
     
     override func didTapButton(sender: UIButton) {
-        
         nextButton.isEnabled = true
         skipButton.isEnabled = true
         if isFail {
             self.view.showToast(message: "알 수 없는 오류가 발생하였습니다.")
             return
         }
-        setUser()
-        postUserInfo()
         if sender == skipButton {
             UserManager.shared.recommendId = ""
             Amplitude.instance().logEvent("click_onboarding_recommend", withEventProperties: ["rec_exist": "pass"] )
         } else if sender == nextButton {
             Amplitude.instance().logEvent("click_onboarding_recommend", withEventProperties: ["rec_exist": "next"] )
         }
+        
+        setUser()
+        postUserInfo()
     }
 }
 


### PR DESCRIPTION
## ⛏ 작업 내용
회원가입 시 카카오에서 정상적으로 넘어오지 않는 경우 기본 값을 넣도록 처리했습니다. 


## 📌 PR Point!
- Firebase의 Crashlytics에서 비정상 종료가 아니더라도 로그를 보낼 수 있는 코드를 작성했습니다. 
``` swift
case .requestErr(let data):
            self.isFail = true
            self.view.showToast(message: "오류가 발생했습니다. 잠시후 다시 시도해주세요.")
            Crashlytics.crashlytics().setUserID(UserManager.shared.yelloId)
            Crashlytics.crashlytics().log("dto: \(requestDTO) \n message: \(data.message)")
            return
```


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 로그인 에러 해결 | 없습니다 |


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #287
