### PR TITLE
Feat [#292] 투표 애니메이션 추가 및 재구독뷰 서버 재연결

### DIFF
--- a/YELLO-iOS/YELLO-iOS/Network/Purchase/DTO/Response/PurchaseSubscibeNeedResponseDTO.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Purchase/DTO/Response/PurchaseSubscibeNeedResponseDTO.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct PurchaseSubscibeNeedResponseDTO: Codable {
+    let id: Int64
     let subscribe: String
-    let isSubscribeNeeded: Bool
+    let expiredDate: String
 }

--- a/YELLO-iOS/YELLO-iOS/Network/Purchase/DTO/Response/PurchaseSubscibeNeedResponseDTO.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Purchase/DTO/Response/PurchaseSubscibeNeedResponseDTO.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct PurchaseSubscibeNeedResponseDTO: Codable {
-    let id: Int64
+    let id: Int
     let subscribe: String
     let expiredDate: String
 }

--- a/YELLO-iOS/YELLO-iOS/Network/Purchase/Router/PurchaseTarget.swift
+++ b/YELLO-iOS/YELLO-iOS/Network/Purchase/Router/PurchaseTarget.swift
@@ -56,7 +56,7 @@ extension PurchaseTarget: TargetType {
         case .purchaseTicket(_):
             return "/purchase/apple/verify/ticket"
         case .purchaseSubscibeNeed:
-            return "/purchase/subscribe"
+            return "/user/subscribe"
         }
     }
     
@@ -66,7 +66,7 @@ extension PurchaseTarget: TargetType {
             return .requestWithBody(requestDTO)
         case let .purchaseTicket(requestDTO):
             return .requestWithBody(requestDTO)
-        case let .purchaseSubscibeNeed:
+        case .purchaseSubscibeNeed:
             return .requestPlain
         }
     }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Subscription/SubscriptionExtensionView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Subscription/SubscriptionExtensionView.swift
@@ -51,10 +51,9 @@ final class SubscriptionExtensionView: BaseView {
 
             if let tomorrow = Calendar.current.date(byAdding: dayComponent, to: today) {
                 let dateFormatter = DateFormatter()
-                dateFormatter.dateFormat = "yyyy-MM-dd"  // 원하는 형식 설정
+                dateFormatter.dateFormat = "yyyy-MM-dd"
                 let dateString = dateFormatter.string(from: tomorrow)
                 $0.text = dateString
-                print(dateString)
             }
             
             $0.setTextWithLineHeight(text: $0.text, lineHeight: 24.adjusted)

--- a/YELLO-iOS/YELLO-iOS/Presentation/TabBar/YELLOTabBarController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/TabBar/YELLOTabBarController.swift
@@ -238,10 +238,25 @@ extension YELLOTabBarController {
             switch result {
             case .success(let data):
                 guard let data = data.data else { return }
-                if data.isSubscribeNeeded {
-                    self.toResubscribeView()
+                
+                let currentDate = Date()
+                let dateFormatter = DateFormatter()
+                dateFormatter.dateFormat = "yyyy-MM-dd"
+                
+                if data.subscribe == "canceled" {
+                    if let expiredDate = dateFormatter.date(from: data.expiredDate) {
+                        // 만료일이 오늘 또는 오늘 이후라면
+                        if currentDate.compare(expiredDate) == .orderedAscending {
+                            // 하루 이하로 남았으면
+                            self.toResubscribeView()
+                        }
+                    }
                 }
+                print("여기야아아아아아ㅏㅇ")
+                print(data)
+                
             default:
+                print("여기야아아아아아ㅏㅇ")
                 print("network failure")
                 return
             }

--- a/YELLO-iOS/YELLO-iOS/Presentation/TabBar/YELLOTabBarController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/TabBar/YELLOTabBarController.swift
@@ -245,18 +245,16 @@ extension YELLOTabBarController {
                 
                 if data.subscribe == "canceled" {
                     if let expiredDate = dateFormatter.date(from: data.expiredDate) {
-                        // 만료일이 오늘 또는 오늘 이후라면
-                        if currentDate.compare(expiredDate) == .orderedAscending {
-                            // 하루 이하로 남았으면
-                            self.toResubscribeView()
+                        let calendar = Calendar.current
+                        if let daysDifference = calendar.dateComponents([.day], from: currentDate, to: expiredDate).day {
+                            if daysDifference <= 1 {
+                                // 하루 이하로 남았으면
+                                self.toResubscribeView()
+                            }
                         }
                     }
                 }
-                print("여기야아아아아아ㅏㅇ")
-                print(data)
-                
             default:
-                print("여기야아아아아아ㅏㅇ")
                 print("network failure")
                 return
             }

--- a/YELLO-iOS/YELLO-iOS/Presentation/TabBar/YELLOTabBarController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/TabBar/YELLOTabBarController.swift
@@ -41,7 +41,7 @@ final class YELLOTabBarController: UITabBarController {
         super.viewDidLoad()
         
         network()
-//        purchaseSubscribeNeed()
+        purchaseSubscribeNeed()
 
         NotificationCenter.default.addObserver(self, selector: #selector(showMessage(_:)), name: NSNotification.Name("showMessage"), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(showPage(_:)), name: NSNotification.Name("showPage"), object: nil)

--- a/YELLO-iOS/YELLO-iOS/Presentation/Voting/Voting/VotingFunction.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Voting/Voting/VotingFunction.swift
@@ -196,9 +196,28 @@ extension VotingViewController {
             saveUserData(combinedData)
             print(combinedData)
             
-            UIView.transition(with: self.navigationController?.view ?? UIView(), duration: 0.5, options: .transitionCrossDissolve, animations: {
-                // 전환 시 스르륵 바뀌는 애니메이션 적용
+            let topAnimatedView = self.originView.questionBackground
+            let nameAnimatedViews = [self.originView.nameOneButton, self.originView.nameTwoButton, self.originView.nameThreeButton, self.originView.nameFourButton]
+            let keywordAnimatedViews = [self.originView.keywordOneButton, self.originView.keywordTwoButton, self.originView.keywordThreeButton, self.originView.keywordFourButton]
+            
+            UIView.animate(withDuration: 0.5, animations: {
+                // 원하는 애니메이션 구현
+                let newXPosition = -200.adjusted
+                topAnimatedView.frame.origin.x = CGFloat(newXPosition)
+                for nameView in nameAnimatedViews {
+                    nameView.frame.origin.x = CGFloat(newXPosition)
+                }
+                for keywordView in keywordAnimatedViews {
+                    keywordView.frame.origin.x = CGFloat(newXPosition + 148.adjusted)
+                }
+                
+                self.keywordMiddleText.frame.origin.x = CGFloat(newXPosition)
+                self.nameMiddleText.frame.origin.x = CGFloat(newXPosition)
+                
                 VotingViewController.pushCount += 1
+
+            }, completion: { _ in
+                // 애니메이션이 완료된 후에 화면 전환
                 self.navigationController?.pushViewController(viewController, animated: false)
             })
         }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Voting/Voting/VotingFunction.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Voting/Voting/VotingFunction.swift
@@ -201,9 +201,14 @@ extension VotingViewController {
             let keywordAnimatedViews = [self.originView.keywordOneButton, self.originView.keywordTwoButton, self.originView.keywordThreeButton, self.originView.keywordFourButton]
             
             UIView.animate(withDuration: 0.5, animations: {
+                // 서서히 사라지게 설정
+                self.nameMiddleText.alpha = 0
+                self.keywordMiddleText.alpha = 0
+                
                 // 원하는 애니메이션 구현
                 let newXPosition = -200.adjusted
                 topAnimatedView.frame.origin.x = CGFloat(newXPosition)
+                
                 for nameView in nameAnimatedViews {
                     nameView.frame.origin.x = CGFloat(newXPosition)
                 }
@@ -211,11 +216,7 @@ extension VotingViewController {
                     keywordView.frame.origin.x = CGFloat(newXPosition + 148.adjusted)
                 }
                 
-                self.keywordMiddleText.frame.origin.x = CGFloat(newXPosition)
-                self.nameMiddleText.frame.origin.x = CGFloat(newXPosition)
-                
                 VotingViewController.pushCount += 1
-
             }, completion: { _ in
                 // 애니메이션이 완료된 후에 화면 전환
                 self.navigationController?.pushViewController(viewController, animated: false)

--- a/YELLO-iOS/YELLO-iOS/Presentation/Voting/Voting/VotingFunction.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Voting/Voting/VotingFunction.swift
@@ -196,29 +196,25 @@ extension VotingViewController {
             saveUserData(combinedData)
             print(combinedData)
             
-            let topAnimatedView = self.originView.questionBackground
-            let nameAnimatedViews = [self.originView.nameOneButton, self.originView.nameTwoButton, self.originView.nameThreeButton, self.originView.nameFourButton]
-            let keywordAnimatedViews = [self.originView.keywordOneButton, self.originView.keywordTwoButton, self.originView.keywordThreeButton, self.originView.keywordFourButton]
+            let topAnimatedView = viewController.originView.questionBackground
+            let nameAnimatedViews = [viewController.originView.nameOneButton, viewController.originView.nameTwoButton, viewController.originView.nameThreeButton, viewController.originView.nameFourButton]
+            let keywordAnimatedViews = [viewController.originView.keywordOneButton, viewController.originView.keywordTwoButton, viewController.originView.keywordThreeButton, viewController.originView.keywordFourButton]
             
-            UIView.animate(withDuration: 0.5, animations: {
-                // 서서히 사라지게 설정
-                self.nameMiddleText.alpha = 0
-                self.keywordMiddleText.alpha = 0
+            UIView.transition(with: self.navigationController?.view ?? UIView(), duration: 0.5, options: .transitionCrossDissolve, animations: {
+                VotingViewController.pushCount += 1
                 
-                // 원하는 애니메이션 구현
-                let newXPosition = -200.adjusted
+                // 검정색 배경들이 밀리는 것과 같은 애니메이션 구현
+                let newXPosition = -1000.adjusted
                 topAnimatedView.frame.origin.x = CGFloat(newXPosition)
                 
-                for nameView in nameAnimatedViews {
-                    nameView.frame.origin.x = CGFloat(newXPosition)
-                }
                 for keywordView in keywordAnimatedViews {
                     keywordView.frame.origin.x = CGFloat(newXPosition + 148.adjusted)
                 }
                 
-                VotingViewController.pushCount += 1
-            }, completion: { _ in
-                // 애니메이션이 완료된 후에 화면 전환
+                for nameView in nameAnimatedViews {
+                    nameView.frame.origin.x = CGFloat(newXPosition)
+                }
+                
                 self.navigationController?.pushViewController(viewController, animated: false)
             })
         }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Voting/Voting/VotingFunction.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Voting/Voting/VotingFunction.swift
@@ -22,7 +22,7 @@ extension VotingViewController {
         view.insertSubview(gradientView, at: 0)
         
         let progressPercent = Float(VotingViewController.pushCount + 1) / 8.0
-        self.originView.progressView.setProgress(progressPercent, animated: true)
+        self.originView.progressView.setProgress(progressPercent, animated: false)
         setAnimationView()
         self.originView.yelloProgress.image =
         dummy[VotingViewController.pushCount].yelloProgress
@@ -200,23 +200,31 @@ extension VotingViewController {
             let nameAnimatedViews = [viewController.originView.nameOneButton, viewController.originView.nameTwoButton, viewController.originView.nameThreeButton, viewController.originView.nameFourButton]
             let keywordAnimatedViews = [viewController.originView.keywordOneButton, viewController.originView.keywordTwoButton, viewController.originView.keywordThreeButton, viewController.originView.keywordFourButton]
             
-            UIView.transition(with: self.navigationController?.view ?? UIView(), duration: 0.5, options: .transitionCrossDissolve, animations: {
-                VotingViewController.pushCount += 1
-                
-                // 검정색 배경들이 밀리는 것과 같은 애니메이션 구현
-                let newXPosition = -1000.adjusted
-                topAnimatedView.frame.origin.x = CGFloat(newXPosition)
-                
-                for keywordView in keywordAnimatedViews {
-                    keywordView.frame.origin.x = CGFloat(newXPosition + 148.adjusted)
-                }
-                
-                for nameView in nameAnimatedViews {
-                    nameView.frame.origin.x = CGFloat(newXPosition)
-                }
-                
-                self.navigationController?.pushViewController(viewController, animated: false)
-            })
+            let transition = CATransition()
+            transition.type = CATransitionType.fade
+            transition.duration = 0.6
+            self.navigationController?.view.layer.add(transition, forKey: nil)
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                UIView.transition(with: self.navigationController?.view ?? UIView(), duration: 0.3, options: .allowUserInteraction, animations: {
+                    VotingViewController.pushCount += 1
+                    
+                    // 검정색 배경들이 밀리는 것과 같은 애니메이션 구현
+                    let newXPosition = -500.adjusted
+                    topAnimatedView.frame.origin.x = CGFloat(newXPosition)
+
+                    for nameView in nameAnimatedViews {
+                        nameView.frame.origin.x = CGFloat(newXPosition)
+                    }
+
+                    for keywordView in keywordAnimatedViews {
+                        keywordView.frame.origin.x = CGFloat(newXPosition + 148.adjusted)
+                    }
+                    
+                    self.navigationController?.pushViewController(viewController, animated: false)
+                })
+            }
+
         }
     }
     

--- a/YELLO-iOS/YELLO-iOS/Presentation/Voting/Voting/VotingViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Voting/Voting/VotingViewController.swift
@@ -29,7 +29,7 @@ final class VotingViewController: BaseViewController {
     
     let originView = BaseVotingMainView()
   
-    private let nameStackView = UIStackView()
+    let nameStackView = UIStackView()
     let nameHead = UILabel()
     var nameMiddleBackground = UIView(frame: CGRect(x: 0, y: 0, width: 70.adjusted, height: 34.adjusted))
 
@@ -41,7 +41,7 @@ final class VotingViewController: BaseViewController {
     var nameTextThree = UILabel()
     var nameTextFour = UILabel()
     
-    private let keywordStackView = UIStackView()
+    let keywordStackView = UIStackView()
     let keywordHead = UILabel()
     var keywordMiddleBackground = UIView(frame: CGRect(x: 0, y: 0, width: 150.adjusted, height: 34.adjusted))
     let keywordMiddleText = UILabel()
@@ -160,7 +160,7 @@ final class VotingViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        Amplitude.instance().logEvent("view_vote_question", withEventProperties: ["vote_step" : VotingViewController.pushCount])
+        Amplitude.instance().logEvent("view_vote_question", withEventProperties: ["vote_step": VotingViewController.pushCount])
         Color.shared.restoreFromUserDefaults()
         votingList = loadVotingData() ?? []
         myPoint = UserDefaults.standard.integer(forKey: "UserPoint")


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 투표하기 중 다음화면으로 넘어갈 때 검정색 배경들이 옆으로 밀리는 것과 같은 애니메이션을 추가했습니다.
- 재구독뷰 관련 서버 URL이 변경됨에 따라 Response DTO와 뷰 구현 부분을 수정했습니다.
<!--
```
작성한 코드가 있다면 여기에 주석을 제거하고 적어주세요!
```
-->


## 📌 PR Point!
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- X


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 투표애니메이션 | ![Simulator Screen Recording - iPhone 15 - 2024-01-25 at 02 55 44](https://github.com/team-yello/YELLO-iOS/assets/97782228/cdb66f64-7b02-4072-a44b-369acf28aadc) |


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #292 
