### PR TITLE
Feat [#296] 탈퇴 사유 뷰 구현

### DIFF
--- a/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
+++ b/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 		36EA2AB72A66FC0B003603C7 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36EA2AB62A66FC0B003603C7 /* UserManager.swift */; };
 		C303C8222B6005500077C423 /* WithdrawalReasonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C303C8212B6005500077C423 /* WithdrawalReasonViewController.swift */; };
 		C303C8242B6005980077C423 /* WithdrawalReasonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C303C8232B6005980077C423 /* WithdrawalReasonView.swift */; };
+		C303C8262B6009C70077C423 /* ReasonCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C303C8252B6009C70077C423 /* ReasonCollectionViewCell.swift */; };
 		C305A5B22A85F997007C4A69 /* PaymentConfirmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C305A5B12A85F997007C4A69 /* PaymentConfirmView.swift */; };
 		C306E7272A630BB70031514C /* KeychainHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C306E7262A630BB70031514C /* KeychainHandler.swift */; };
 		C306E72A2A630BD10031514C /* SwiftKeychainWrapper in Frameworks */ = {isa = PBXBuildFile; productRef = C306E7292A630BD10031514C /* SwiftKeychainWrapper */; };
@@ -484,6 +485,7 @@
 		36EA2AB62A66FC0B003603C7 /* UserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
 		C303C8212B6005500077C423 /* WithdrawalReasonViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalReasonViewController.swift; sourceTree = "<group>"; };
 		C303C8232B6005980077C423 /* WithdrawalReasonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalReasonView.swift; sourceTree = "<group>"; };
+		C303C8252B6009C70077C423 /* ReasonCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReasonCollectionViewCell.swift; sourceTree = "<group>"; };
 		C305A5B12A85F997007C4A69 /* PaymentConfirmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentConfirmView.swift; sourceTree = "<group>"; };
 		C306E7262A630BB70031514C /* KeychainHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHandler.swift; sourceTree = "<group>"; };
 		C306E73A2A64557D0031514C /* RecommendingFriendRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendingFriendRequestDTO.swift; sourceTree = "<group>"; };
@@ -1317,6 +1319,14 @@
 			path = Helper;
 			sourceTree = "<group>";
 		};
+		C303C8272B6009CE0077C423 /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				C303C8252B6009C70077C423 /* ReasonCollectionViewCell.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
 		C305A5B02A85F2CE007C4A69 /* Button */ = {
 			isa = PBXGroup;
 			children = (
@@ -1905,6 +1915,7 @@
 			children = (
 				C3FF24A92A5F330700A97D40 /* ViewController */,
 				C3FF24AA2A5F331000A97D40 /* View */,
+				C303C8272B6009CE0077C423 /* Cell */,
 			);
 			path = Withdrawal;
 			sourceTree = "<group>";
@@ -1962,8 +1973,8 @@
 		C3FF24A92A5F330700A97D40 /* ViewController */ = {
 			isa = PBXGroup;
 			children = (
-				C3FF24722A5D47EB00A97D40 /* WithdrawalCheckViewController.swift */,
 				C3FF246B2A5D476D00A97D40 /* WithdrawalViewController.swift */,
+				C3FF24722A5D47EB00A97D40 /* WithdrawalCheckViewController.swift */,
 				C303C8212B6005500077C423 /* WithdrawalReasonViewController.swift */,
 			);
 			path = ViewController;
@@ -1972,10 +1983,10 @@
 		C3FF24AA2A5F331000A97D40 /* View */ = {
 			isa = PBXGroup;
 			children = (
-				C3FF24702A5D47DD00A97D40 /* WithdrawalCheckView.swift */,
 				C3FF246E2A5D47D100A97D40 /* WithdrawalView.swift */,
-				C3FF24742A5D6E9500A97D40 /* WithdrawalAlertView.swift */,
+				C3FF24702A5D47DD00A97D40 /* WithdrawalCheckView.swift */,
 				C303C8232B6005980077C423 /* WithdrawalReasonView.swift */,
+				C3FF24742A5D6E9500A97D40 /* WithdrawalAlertView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -2389,6 +2400,7 @@
 				C3A799C22A494B0F00D3EFD8 /* Font.swift in Sources */,
 				C363D46D2A78050600FD583D /* AroundTableViewCell.swift in Sources */,
 				C3FF24B32A5F4D1F00A97D40 /* BasePaddingLabel.swift in Sources */,
+				C303C8262B6009C70077C423 /* ReasonCollectionViewCell.swift in Sources */,
 				C3FF246F2A5D47D100A97D40 /* WithdrawalView.swift in Sources */,
 				362EC3192A8BAC8E00121BDD /* ThirdTutorialView.swift in Sources */,
 				C3A799C02A494B0200D3EFD8 /* String.swift in Sources */,

--- a/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
+++ b/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
@@ -178,6 +178,8 @@
 		36E60EC32AE6DFC4005035D3 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EC22AE6DFC4005035D3 /* FirebaseStorage */; };
 		36E60EC52AE6DFC4005035D3 /* FirebaseStorageCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 36E60EC42AE6DFC4005035D3 /* FirebaseStorageCombine-Community */; };
 		36EA2AB72A66FC0B003603C7 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36EA2AB62A66FC0B003603C7 /* UserManager.swift */; };
+		C303C8222B6005500077C423 /* WithdrawalReasonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C303C8212B6005500077C423 /* WithdrawalReasonViewController.swift */; };
+		C303C8242B6005980077C423 /* WithdrawalReasonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C303C8232B6005980077C423 /* WithdrawalReasonView.swift */; };
 		C305A5B22A85F997007C4A69 /* PaymentConfirmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C305A5B12A85F997007C4A69 /* PaymentConfirmView.swift */; };
 		C306E7272A630BB70031514C /* KeychainHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C306E7262A630BB70031514C /* KeychainHandler.swift */; };
 		C306E72A2A630BD10031514C /* SwiftKeychainWrapper in Frameworks */ = {isa = PBXBuildFile; productRef = C306E7292A630BD10031514C /* SwiftKeychainWrapper */; };
@@ -480,6 +482,8 @@
 		36E427942A5CA59F0050B34E /* OnboardingEndViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingEndViewController.swift; sourceTree = "<group>"; };
 		36E427962A5CA5AF0050B34E /* OnboardingEndView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingEndView.swift; sourceTree = "<group>"; };
 		36EA2AB62A66FC0B003603C7 /* UserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
+		C303C8212B6005500077C423 /* WithdrawalReasonViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalReasonViewController.swift; sourceTree = "<group>"; };
+		C303C8232B6005980077C423 /* WithdrawalReasonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalReasonView.swift; sourceTree = "<group>"; };
 		C305A5B12A85F997007C4A69 /* PaymentConfirmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentConfirmView.swift; sourceTree = "<group>"; };
 		C306E7262A630BB70031514C /* KeychainHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHandler.swift; sourceTree = "<group>"; };
 		C306E73A2A64557D0031514C /* RecommendingFriendRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendingFriendRequestDTO.swift; sourceTree = "<group>"; };
@@ -1960,6 +1964,7 @@
 			children = (
 				C3FF24722A5D47EB00A97D40 /* WithdrawalCheckViewController.swift */,
 				C3FF246B2A5D476D00A97D40 /* WithdrawalViewController.swift */,
+				C303C8212B6005500077C423 /* WithdrawalReasonViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -1970,6 +1975,7 @@
 				C3FF24702A5D47DD00A97D40 /* WithdrawalCheckView.swift */,
 				C3FF246E2A5D47D100A97D40 /* WithdrawalView.swift */,
 				C3FF24742A5D6E9500A97D40 /* WithdrawalAlertView.swift */,
+				C303C8232B6005980077C423 /* WithdrawalReasonView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -2389,6 +2395,7 @@
 				C306E73D2A6455CA0031514C /* RecommendingFriendResponseDTO.swift in Sources */,
 				C3A799CB2A494C7500D3EFD8 /* BaseViewController.swift in Sources */,
 				C30F81092A7F732B009DBB8D /* HintButton.swift in Sources */,
+				C303C8242B6005980077C423 /* WithdrawalReasonView.swift in Sources */,
 				C3FF24A42A5EEBF100A97D40 /* DetailSenderView.swift in Sources */,
 				C3B83E682A8E08D500A39CAC /* PurchaseService.swift in Sources */,
 				36C4C4A62AB8C29400F968B7 /* HighSchoolSearchRequestQueryDTO.swift in Sources */,
@@ -2397,6 +2404,7 @@
 				2A3705DC2A62E386001AAC93 /* VotingTarget.swift in Sources */,
 				C3DC4ADA2A5FE713001DCE04 /* PaymentViewController.swift in Sources */,
 				367DA01B2A863CE60043D23C /* HighSchoolViewController.swift in Sources */,
+				C303C8222B6005500077C423 /* WithdrawalReasonViewController.swift in Sources */,
 				2AD1A1D62A5C952000CB988B /* VotingFunction.swift in Sources */,
 				C3D2664F2A5D1FA50041C7C7 /* SettingNavigationBarView.swift in Sources */,
 				2A3705C82A62E297001AAC93 /* SignUpResponseDTO.swift in Sources */,

--- a/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
+++ b/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
@@ -293,6 +293,7 @@
 		C3C57BF52A5C093D00B84CAA /* FriendModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C57BF42A5C093D00B84CAA /* FriendModel.swift */; };
 		C3C57BF72A5C0BD700B84CAA /* EmptyFriendView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C57BF62A5C0BD700B84CAA /* EmptyFriendView.swift */; };
 		C3C57BF92A5C181A00B84CAA /* SchoolFriendView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C57BF82A5C181A00B84CAA /* SchoolFriendView.swift */; };
+		C3C5D8232B628AC500C8D27C /* ReasonHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C5D8222B628AC500C8D27C /* ReasonHeaderView.swift */; };
 		C3D266392A5C710D0041C7C7 /* NavigationBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D266382A5C710D0041C7C7 /* NavigationBarView.swift */; };
 		C3D2663B2A5C720F0041C7C7 /* CountCustomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D2663A2A5C720F0041C7C7 /* CountCustomView.swift */; };
 		C3D2663D2A5C73360041C7C7 /* MyProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D2663C2A5C73360041C7C7 /* MyProfileView.swift */; };
@@ -595,6 +596,7 @@
 		C3C57BF42A5C093D00B84CAA /* FriendModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendModel.swift; sourceTree = "<group>"; };
 		C3C57BF62A5C0BD700B84CAA /* EmptyFriendView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyFriendView.swift; sourceTree = "<group>"; };
 		C3C57BF82A5C181A00B84CAA /* SchoolFriendView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchoolFriendView.swift; sourceTree = "<group>"; };
+		C3C5D8222B628AC500C8D27C /* ReasonHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReasonHeaderView.swift; sourceTree = "<group>"; };
 		C3D266382A5C710D0041C7C7 /* NavigationBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarView.swift; sourceTree = "<group>"; };
 		C3D2663A2A5C720F0041C7C7 /* CountCustomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountCustomView.swift; sourceTree = "<group>"; };
 		C3D2663C2A5C73360041C7C7 /* MyProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyProfileView.swift; sourceTree = "<group>"; };
@@ -1987,6 +1989,7 @@
 				C3FF24702A5D47DD00A97D40 /* WithdrawalCheckView.swift */,
 				C303C8232B6005980077C423 /* WithdrawalReasonView.swift */,
 				C3FF24742A5D6E9500A97D40 /* WithdrawalAlertView.swift */,
+				C3C5D8222B628AC500C8D27C /* ReasonHeaderView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -2340,6 +2343,7 @@
 				C3C57BEC2A5C03BA00B84CAA /* InviteBannerView.swift in Sources */,
 				C3A799E92A494D6800D3EFD8 /* UITextField+.swift in Sources */,
 				C390B8142A8A1DD800EA5A23 /* AroundResponseDTO.swift in Sources */,
+				C3C5D8232B628AC500C8D27C /* ReasonHeaderView.swift in Sources */,
 				2A3705DA2A62E35F001AAC93 /* VotingAvailableResponseDTO.swift in Sources */,
 				36BF1DE42A7A30CF00C58E74 /* SchoolSelectView.swift in Sources */,
 				C3D266392A5C710D0041C7C7 /* NavigationBarView.swift in Sources */,

--- a/YELLO-iOS/YELLO-iOS/Global/Literals/String.swift
+++ b/YELLO-iOS/YELLO-iOS/Global/Literals/String.swift
@@ -366,6 +366,20 @@ enum StringLiterals {
             static let no = "아니요"
             static let yes = "네, 탈퇴합니다"
         }
+        
+        enum WithdrawalReason {
+            static let title = "탈퇴 사유를 적어주세요."
+            static let nobody = "앱에 아는 사람들이 없어서"
+            static let expensive = "구독권과 열람권의 가격이 비싸서"
+            static let error = "오류가 많아서"
+            static let notFunny = "재밌는 콘텐츠 또는 질문이 없어서"
+            static let lessPoint = "포인트를 너무 적게 줘서"
+            static let delete = "내 정보를 삭제하고 싶어서"
+            static let otherApp = "다른 앱이 더 재밌어서"
+            static let etc = "기타"
+            static let etcReason = "사유를 적어주세요.(최대 30자)"
+            static let complete = "완료"
+        }
     }
     
     enum PushAlarm {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/Cell/ReasonCollectionViewCell.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/Cell/ReasonCollectionViewCell.swift
@@ -20,6 +20,8 @@ final class ReasonCollectionViewCell: UICollectionViewCell {
     let unselectedView = UIView()
     let selectedView = UIView()
     let descriptionLabel = UILabel()
+    let etcTextView = UITextView()
+    
     var isReasonSelected = false {
         didSet {
             setButtonStyle()
@@ -31,10 +33,15 @@ final class ReasonCollectionViewCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setUI()
+        setDelegate()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setDelegate() {
+        etcTextView.delegate = self
     }
     
     private func setUI() {
@@ -67,25 +74,32 @@ final class ReasonCollectionViewCell: UICollectionViewCell {
             $0.font = .uiBodyLarge
             $0.isUserInteractionEnabled = false
         }
+        
+        etcTextView.do {
+            $0.font = .uiBody02
+            $0.textColor = .grayscales600
+            $0.textAlignment = .left
+            $0.makeCornerRound(radius: 8.adjustedHeight)
+            $0.backgroundColor = .grayscales800
+            $0.isHidden = true
+        }
     }
     
     private func setLayout() {
         self.addSubviews(reasonView)
         reasonView.addSubviews(unselectedView,
-                                 descriptionLabel)
+                               descriptionLabel,
+                               etcTextView)
+        
         unselectedView.addSubview(selectedView)
         
-        self.snp.makeConstraints {
+        reasonView.snp.makeConstraints {
             $0.width.equalTo(UIScreen.main.bounds.width - 68.adjustedWidth)
             $0.height.equalTo(56.adjustedHeight)
         }
         
-        reasonView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
-        
         unselectedView.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
+            $0.top.equalToSuperview().inset(20.adjustedHeight)
             $0.leading.equalToSuperview().inset(16.adjustedWidth)
             $0.width.height.equalTo(18.adjusted)
         }
@@ -96,8 +110,16 @@ final class ReasonCollectionViewCell: UICollectionViewCell {
         }
         
         descriptionLabel.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
+            $0.centerY.equalTo(unselectedView)
             $0.leading.equalTo(unselectedView.snp.trailing).offset(8.adjustedWidth)
+        }
+        
+        etcTextView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(45.adjustedHeight)
+            $0.leading.trailing.equalToSuperview().inset(16.adjustedWidth)
+            $0.height.equalTo(76.adjustedHeight)
+            $0.width.equalTo(275.adjustedWidth)
+            $0.bottom.equalToSuperview().inset(20.adjustedHeight)
         }
     }
     
@@ -116,10 +138,35 @@ final class ReasonCollectionViewCell: UICollectionViewCell {
             }
             
             selectedView.isHidden = true
+            
+        }
+    }
+    
+    func setTextView(isEtc: Bool) {
+        etcTextView.isHidden = !isEtc
+        if isEtc {
+            reasonView.snp.updateConstraints {
+                $0.width.equalTo(UIScreen.main.bounds.width - 68.adjustedWidth)
+                $0.height.equalTo(141.adjustedHeight)
+            }
+        } else {
+            reasonView.snp.updateConstraints {
+                $0.width.equalTo(UIScreen.main.bounds.width - 68.adjustedWidth)
+                $0.height.equalTo(56.adjustedHeight)
+            }
         }
     }
     
     func dataBind(data: String) {
         self.descriptionLabel.text = data
+    }
+}
+
+extension ReasonCollectionViewCell: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.text == StringLiterals.Profile.WithdrawalReason.etcReason {
+            textView.text = nil
+            textView.textColor = .white
+        }
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/Cell/ReasonCollectionViewCell.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/Cell/ReasonCollectionViewCell.swift
@@ -71,7 +71,6 @@ final class ReasonCollectionViewCell: UICollectionViewCell {
         }
         
         etcTextView.do {
-            $0.text = StringLiterals.Profile.WithdrawalReason.etcReason
             $0.font = .uiBody02
             $0.textColor = .grayscales600
             $0.textAlignment = .left

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/Cell/ReasonCollectionViewCell.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/Cell/ReasonCollectionViewCell.swift
@@ -33,15 +33,10 @@ final class ReasonCollectionViewCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setUI()
-        setDelegate()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func setDelegate() {
-        etcTextView.delegate = self
     }
     
     private func setUI() {
@@ -53,7 +48,7 @@ final class ReasonCollectionViewCell: UICollectionViewCell {
         reasonView.do {
             $0.makeCornerRound(radius: 8.adjustedHeight)
             $0.backgroundColor = .grayscales900
-            $0.isUserInteractionEnabled = false
+            $0.isUserInteractionEnabled = true
         }
         
         unselectedView.do {
@@ -85,6 +80,7 @@ final class ReasonCollectionViewCell: UICollectionViewCell {
             $0.isHidden = true
             $0.textContainerInset = UIEdgeInsets(top: 12.adjustedHeight, left: 14.adjustedWidth, bottom: 12.adjustedHeight, right: 14.adjustedWidth)
             $0.isUserInteractionEnabled = true
+            $0.accessibilityRespondsToUserInteraction = true
         }
     }
     
@@ -141,7 +137,6 @@ final class ReasonCollectionViewCell: UICollectionViewCell {
             }
             
             selectedView.isHidden = true
-            
         }
     }
     
@@ -152,6 +147,8 @@ final class ReasonCollectionViewCell: UICollectionViewCell {
                 $0.width.equalTo(UIScreen.main.bounds.width - 68.adjustedWidth)
                 $0.height.equalTo(141.adjustedHeight)
             }
+            etcTextView.becomeFirstResponder()
+            
         } else {
             reasonView.snp.updateConstraints {
                 $0.width.equalTo(UIScreen.main.bounds.width - 68.adjustedWidth)
@@ -162,14 +159,5 @@ final class ReasonCollectionViewCell: UICollectionViewCell {
     
     func dataBind(data: String) {
         self.descriptionLabel.text = data
-    }
-}
-
-extension ReasonCollectionViewCell: UITextViewDelegate {
-    func textViewDidBeginEditing(_ textView: UITextView) {
-        if textView.text == StringLiterals.Profile.WithdrawalReason.etcReason {
-            textView.text = nil
-            textView.textColor = .white
-        }
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/Cell/ReasonCollectionViewCell.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/Cell/ReasonCollectionViewCell.swift
@@ -146,9 +146,7 @@ final class ReasonCollectionViewCell: UICollectionViewCell {
             reasonView.snp.updateConstraints {
                 $0.width.equalTo(UIScreen.main.bounds.width - 68.adjustedWidth)
                 $0.height.equalTo(141.adjustedHeight)
-            }
-            etcTextView.becomeFirstResponder()
-            
+            }            
         } else {
             reasonView.snp.updateConstraints {
                 $0.width.equalTo(UIScreen.main.bounds.width - 68.adjustedWidth)

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/Cell/ReasonCollectionViewCell.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/Cell/ReasonCollectionViewCell.swift
@@ -15,7 +15,8 @@ final class ReasonCollectionViewCell: UICollectionViewCell {
     // MARK: - Variables
     // MARK: Constants
     static let identifier = "ReasonCollectionViewCell"
-    let reasonButton = UIButton()
+    
+    let reasonView = UIView()
     let unselectedView = UIView()
     let selectedView = UIView()
     let descriptionLabel = UILabel()
@@ -36,48 +37,51 @@ final class ReasonCollectionViewCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func prepareForReuse() {
-        super.prepareForReuse()
-    }
-    
     private func setUI() {
         setStyle()
         setLayout()
     }
     
     private func setStyle() {
-        reasonButton.do {
+        reasonView.do {
             $0.makeCornerRound(radius: 8.adjustedHeight)
-            $0.backgroundColor = .grayscales700
+            $0.backgroundColor = .grayscales900
+            $0.isUserInteractionEnabled = false
         }
         
         unselectedView.do {
             $0.makeCornerRound(radius: 9.adjusted)
             $0.makeBorder(width: 2, color: .grayscales700)
-            $0.backgroundColor = .clear
+            $0.isUserInteractionEnabled = false
         }
         
         selectedView.do {
             $0.makeCornerRound(radius: 4.adjusted)
             $0.backgroundColor = .white
             $0.isHidden = true
+            $0.isUserInteractionEnabled = false
         }
         
         descriptionLabel.do {
             $0.textColor = .white
             $0.font = .uiBodyLarge
+            $0.isUserInteractionEnabled = false
         }
     }
     
     private func setLayout() {
-        self.addSubviews(reasonButton)
-        reasonButton.addSubviews(unselectedView,
+        self.addSubviews(reasonView)
+        reasonView.addSubviews(unselectedView,
                                  descriptionLabel)
         unselectedView.addSubview(selectedView)
         
-        reasonButton.snp.makeConstraints {
-            $0.top.equalTo(56.adjustedHeight)
+        self.snp.makeConstraints {
             $0.width.equalTo(UIScreen.main.bounds.width - 68.adjustedWidth)
+            $0.height.equalTo(56.adjustedHeight)
+        }
+        
+        reasonView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
         
         unselectedView.snp.makeConstraints {
@@ -99,19 +103,23 @@ final class ReasonCollectionViewCell: UICollectionViewCell {
     
     private func setButtonStyle() {
         if isReasonSelected {
-            reasonButton.do {
+            reasonView.do {
                 $0.backgroundColor = .black
                 $0.makeBorder(width: 1, color: .white)
             }
             
             selectedView.isHidden = false
         } else {
-            reasonButton.do {
-                $0.backgroundColor = .grayscales700
+            reasonView.do {
+                $0.backgroundColor = .grayscales900
                 $0.makeBorder(width: 0, color: .clear)
             }
             
             selectedView.isHidden = true
         }
+    }
+    
+    func dataBind(data: String) {
+        self.descriptionLabel.text = data
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/Cell/ReasonCollectionViewCell.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/Cell/ReasonCollectionViewCell.swift
@@ -1,0 +1,117 @@
+//
+//  ReasonCollectionViewCell.swift
+//  YELLO-iOS
+//
+//  Created by 정채은 on 1/23/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class ReasonCollectionViewCell: UICollectionViewCell {
+    
+    // MARK: - Variables
+    // MARK: Constants
+    static let identifier = "ReasonCollectionViewCell"
+    let reasonButton = UIButton()
+    let unselectedView = UIView()
+    let selectedView = UIView()
+    let descriptionLabel = UILabel()
+    var isReasonSelected = false {
+        didSet {
+            setButtonStyle()
+        }
+    }
+    
+    // MARK: - Function
+    // MARK: LifeCycle
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+    }
+    
+    private func setUI() {
+        setStyle()
+        setLayout()
+    }
+    
+    private func setStyle() {
+        reasonButton.do {
+            $0.makeCornerRound(radius: 8.adjustedHeight)
+            $0.backgroundColor = .grayscales700
+        }
+        
+        unselectedView.do {
+            $0.makeCornerRound(radius: 9.adjusted)
+            $0.makeBorder(width: 2, color: .grayscales700)
+            $0.backgroundColor = .clear
+        }
+        
+        selectedView.do {
+            $0.makeCornerRound(radius: 4.adjusted)
+            $0.backgroundColor = .white
+            $0.isHidden = true
+        }
+        
+        descriptionLabel.do {
+            $0.textColor = .white
+            $0.font = .uiBodyLarge
+        }
+    }
+    
+    private func setLayout() {
+        self.addSubviews(reasonButton)
+        reasonButton.addSubviews(unselectedView,
+                                 descriptionLabel)
+        unselectedView.addSubview(selectedView)
+        
+        reasonButton.snp.makeConstraints {
+            $0.top.equalTo(56.adjustedHeight)
+            $0.width.equalTo(UIScreen.main.bounds.width - 68.adjustedWidth)
+        }
+        
+        unselectedView.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().inset(16.adjustedWidth)
+            $0.width.height.equalTo(18.adjusted)
+        }
+        
+        selectedView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.width.height.equalTo(8.adjusted)
+        }
+        
+        descriptionLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(unselectedView.snp.trailing).offset(8.adjustedWidth)
+        }
+    }
+    
+    private func setButtonStyle() {
+        if isReasonSelected {
+            reasonButton.do {
+                $0.backgroundColor = .black
+                $0.makeBorder(width: 1, color: .white)
+            }
+            
+            selectedView.isHidden = false
+        } else {
+            reasonButton.do {
+                $0.backgroundColor = .grayscales700
+                $0.makeBorder(width: 0, color: .clear)
+            }
+            
+            selectedView.isHidden = true
+        }
+    }
+}

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/Cell/ReasonCollectionViewCell.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/Cell/ReasonCollectionViewCell.swift
@@ -76,12 +76,15 @@ final class ReasonCollectionViewCell: UICollectionViewCell {
         }
         
         etcTextView.do {
+            $0.text = StringLiterals.Profile.WithdrawalReason.etcReason
             $0.font = .uiBody02
             $0.textColor = .grayscales600
             $0.textAlignment = .left
             $0.makeCornerRound(radius: 8.adjustedHeight)
             $0.backgroundColor = .grayscales800
             $0.isHidden = true
+            $0.textContainerInset = UIEdgeInsets(top: 12.adjustedHeight, left: 14.adjustedWidth, bottom: 12.adjustedHeight, right: 14.adjustedWidth)
+            $0.isUserInteractionEnabled = true
         }
     }
     

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/ReasonHeaderView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/ReasonHeaderView.swift
@@ -1,0 +1,44 @@
+//
+//  ReasonHeaderView.swift
+//  YELLO-iOS
+//
+//  Created by 정채은 on 1/25/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class ReasonHeaderView: UICollectionReusableView {
+    static let identifier = "ReasonHeaderView"
+    
+    let titleLabel = UILabel()
+    
+    func setUI() {
+        setStyle()
+        setLayout()
+    }
+    
+    private func setStyle() {
+        titleLabel.do {
+            $0.setTextWithLineHeight(text: StringLiterals.Profile.WithdrawalReason.title, lineHeight: 32.adjustedHeight)
+            $0.font = .uiHeadline01
+            $0.textColor = .white
+        }
+    }
+    
+    private func setLayout() {
+        self.addSubviews(titleLabel)
+        
+        self.snp.makeConstraints {
+            $0.height.equalTo(91.adjustedHeight)
+            $0.width.equalTo(UIScreen.main.bounds.width)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(39.adjustedHeight)
+            $0.centerX.equalToSuperview()
+        }
+    }
+}

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalAlertView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalAlertView.swift
@@ -27,11 +27,12 @@ final class WithdrawalAlertView: BaseView {
     override func setStyle() {
         self.backgroundColor = .black.withAlphaComponent(0.5)
         
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(noButtonClicked))
+        self.addGestureRecognizer(tapGestureRecognizer)
+        
         contentsView.do {
             $0.makeCornerRound(radius: 12.adjustedHeight)
             $0.backgroundColor = .grayscales900
-            let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(noButtonClicked))
-            $0.addGestureRecognizer(tapGestureRecognizer)
         }
         
         titleLabel.do {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalAlertView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalAlertView.swift
@@ -27,8 +27,12 @@ final class WithdrawalAlertView: BaseView {
     override func setStyle() {
         self.backgroundColor = .black.withAlphaComponent(0.5)
         
-        contentsView.makeCornerRound(radius: 12.adjustedHeight)
-        contentsView.backgroundColor = .grayscales900
+        contentsView.do {
+            $0.makeCornerRound(radius: 12.adjustedHeight)
+            $0.backgroundColor = .grayscales900
+            let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(noButtonClicked))
+            $0.addGestureRecognizer(tapGestureRecognizer)
+        }
         
         titleLabel.do {
             $0.setTextWithLineHeight(text: StringLiterals.Profile.WithdrawalAlert.title, lineHeight: 22.adjustedHeight)

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalCheckView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalCheckView.swift
@@ -66,7 +66,6 @@ final class WithdrawalCheckView: BaseView {
             $0.titleLabel?.font = .uiBodyMedium
             $0.setTitleColor(.semanticStatusRed500, for: .normal)
             $0.setTitle(StringLiterals.Profile.WithdrawalCheck.confirm, for: .normal)
-            $0.addTarget(self, action: #selector(showAlert), for: .touchUpInside)
         }
     }
     
@@ -119,22 +118,5 @@ final class WithdrawalCheckView: BaseView {
             $0.height.equalTo(48.adjustedHeight)
             $0.width.equalTo(343.adjustedWidth)
         }
-    }
-    
-    // MARK: Objc Function
-    @objc func showAlert() {
-        Amplitude.instance().logEvent("click_profile_withdrawal", withEventProperties: ["withdrawal_button":"withdrawal3"])
-        guard let viewController = UIApplication.shared.keyWindow?.rootViewController else { return }
-        
-        if let withdrawalAlertView = withdrawalAlertView {
-            withdrawalAlertView.removeFromSuperview()
-        }
-        
-        withdrawalAlertView = WithdrawalAlertView()
-        withdrawalAlertView?.frame = viewController.view.bounds
-        withdrawalAlertView?.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        
-        viewController.view.addSubview(withdrawalAlertView!)
-        
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
@@ -27,6 +27,7 @@ final class WithdrawalReasonView: BaseView {
         }
     }
     var etcReason: String = ""
+    var tap = UITapGestureRecognizer()
     
     let withdrawalNavigationBarView = SettingNavigationBarView()
     let reasonHeaderView = ReasonHeaderView()
@@ -42,7 +43,6 @@ final class WithdrawalReasonView: BaseView {
     }
     
     override func setStyle() {
-        hideKeyboardWhenTappedAround()
         self.backgroundColor = .black
         
         withdrawalNavigationBarView.do {
@@ -147,6 +147,7 @@ extension WithdrawalReasonView: UICollectionViewDataSource {
             cell.setTextView(isEtc: true)
             cell.etcTextView.isUserInteractionEnabled = true
             cell.etcTextView.delegate = self
+            self.hideKeyboardWhenTappedAround()
         } else {
             cell.setTextView(isEtc: false)
         }
@@ -163,6 +164,10 @@ extension WithdrawalReasonView: UICollectionViewDataSource {
             selectedIndex = indexPath.row
             isCompleteEnabled = selectedIndex != 7 ? true : false
             reasonCollectionView.reloadData()
+            if indexPath.row == 7 {
+                let indexPath = IndexPath(item: self.reasonList.count - 1, section: 0)
+                reasonCollectionView.scrollToItem(at: indexPath, at: .bottom, animated: true)
+            }
         }
     }
 }
@@ -215,31 +220,30 @@ extension WithdrawalReasonView: UITextViewDelegate {
 
 extension WithdrawalReasonView {
     func hideKeyboardWhenTappedAround() {
-        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
-        tap.cancelsTouchesInView = false
+        tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tap.cancelsTouchesInView = true
         self.addGestureRecognizer(tap)
     }
     
     @objc func dismissKeyboard() {
         self.endEditing(true)
+        self.removeGestureRecognizer(tap)
     }
     
     @objc func keyboardWillShow(_ notification: Notification) {
         if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
-            reasonCollectionView.snp.updateConstraints {
-                $0.bottom.equalToSuperview().inset(26.adjustedHeight + keyboardSize.height)
-            }
-            let indexPath = IndexPath(item: self.reasonList.count - 1, section: 0)
-            reasonCollectionView.scrollToItem(at: indexPath, at: .top, animated: true)
+            let scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: keyboardSize.height, right: 0)
+            reasonCollectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 26.adjustedHeight, right: 0)
+            reasonCollectionView.scrollIndicatorInsets = scrollIndicatorInsets
         }
+        let indexPath = IndexPath(item: self.reasonList.count - 1, section: 0)
+        reasonCollectionView.scrollToItem(at: indexPath, at: .bottom, animated: true)
     }
 
     @objc func keyboardWillHide(_ notification: Notification) {
-        reasonCollectionView.snp.updateConstraints {
-            $0.bottom.equalToSuperview().inset(82.adjustedHeight)
-        }
+        reasonCollectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 26.adjustedHeight, right: 0)
+        reasonCollectionView.scrollIndicatorInsets = .zero
     }
 }
 
-// TODO: 스크롤 수정
-// TODO: Return 버튼 누르면 키보드 사라지도록
+// TODO: 플레이스 홀더 오류.. 수정

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
@@ -21,6 +21,11 @@ final class WithdrawalReasonView: BaseView {
                       StringLiterals.Profile.WithdrawalReason.otherApp,
                       StringLiterals.Profile.WithdrawalReason.etc]    
     var selectedIndex = -1
+    var isCompleteEnabled = false {
+        didSet {
+            self.setCompleteButton(isEnabled: isCompleteEnabled)
+        }
+    }
     
     let withdrawalNavigationBarView = SettingNavigationBarView()
     let reasonHeaderView = ReasonHeaderView()
@@ -57,12 +62,13 @@ final class WithdrawalReasonView: BaseView {
         
         completeButton.do {
             $0.backgroundColor = .black
-            $0.layer.borderColor = UIColor.grayscales700.cgColor
+            $0.layer.borderColor = UIColor.grayscales600.cgColor
             $0.layer.borderWidth = 1
             $0.layer.cornerRadius = 24.adjustedHeight
             $0.titleLabel?.font = .uiBodyMedium
-            $0.setTitleColor(.semanticStatusRed500, for: .normal)
+            $0.setTitleColor(.grayscales600, for: .normal)
             $0.setTitle(StringLiterals.Profile.WithdrawalReason.complete, for: .normal)
+            $0.isEnabled = false
         }
     }
     
@@ -96,6 +102,14 @@ final class WithdrawalReasonView: BaseView {
             $0.height.equalTo(48.adjustedHeight)
             $0.width.equalTo(343.adjustedWidth)
             $0.bottom.equalToSuperview().inset(34.adjustedHeight)
+        }
+    }
+    
+    func setCompleteButton(isEnabled: Bool) {
+        completeButton.do {
+            $0.layer.borderColor = isEnabled ? UIColor.grayscales700.cgColor : UIColor.grayscales600.cgColor
+            $0.setTitleColor(isEnabled ? .semanticStatusRed500 : .grayscales600, for: .normal)
+            $0.isEnabled = isEnabled
         }
     }
 }
@@ -136,6 +150,9 @@ extension WithdrawalReasonView: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        print(indexPath.row)
+        // 추후 사유 빈칸일 때 제외로 수정
+        isCompleteEnabled = true
         selectedIndex = indexPath.row
         reasonCollectionView.reloadData()
     }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
@@ -7,14 +7,142 @@
 
 import UIKit
 
-class WithdrawalReasonView: UIView {
+import SnapKit
+import Then
 
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+final class WithdrawalReasonView: BaseView {
+
+    let reasonList: [String] = [StringLiterals.Profile.WithdrawalReason.nobody,
+                                StringLiterals.Profile.WithdrawalReason.expensive,
+                                StringLiterals.Profile.WithdrawalReason.error,
+                                StringLiterals.Profile.WithdrawalReason.notFunny,
+                                StringLiterals.Profile.WithdrawalReason.lessPoint,
+                                StringLiterals.Profile.WithdrawalReason.delete,
+                                StringLiterals.Profile.WithdrawalReason.otherApp,
+                                StringLiterals.Profile.WithdrawalReason.etc]
+    var selectedIndex = -1
+    
+    let withdrawalNavigationBarView = SettingNavigationBarView()
+    private let scrollView = UIScrollView()
+    private let titleLabel = UILabel()
+    lazy var reasonCollectionView = UICollectionView(frame: .zero, collectionViewLayout: reasonFlowLayout)
+    let reasonFlowLayout = UICollectionViewFlowLayout()
+    let completeButton = UIButton()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setCollectionView()
     }
-    */
+    
+    private func setCollectionView() {
+        reasonCollectionView.register(ReasonCollectionViewCell.self, forCellWithReuseIdentifier: ReasonCollectionViewCell.identifier)
+        reasonCollectionView.delegate = self
+        reasonCollectionView.dataSource = self
+    }
+    
+    override func setStyle() {
+        withdrawalNavigationBarView.do {
+            $0.titleLabel.setTextWithLineHeight(text: StringLiterals.Profile.WithdrawalCheck.withdrawal, lineHeight: 24.adjustedHeight)
+            $0.backgroundColor = .black
+        }
+        
+        scrollView.do {
+            $0.backgroundColor = .black
+        }
+        
+        titleLabel.do {
+            $0.setTextWithLineHeight(text: StringLiterals.Profile.WithdrawalReason.title, lineHeight: 32.adjustedHeight)
+            $0.font = .uiHeadline01
+            $0.textColor = .white
+        }
+        
+        reasonCollectionView.do {
+            $0.backgroundColor = .clear
+            $0.showsVerticalScrollIndicator = false
+            $0.isScrollEnabled = false
+        }
+        
+        reasonFlowLayout.do {
+            $0.scrollDirection = .horizontal
+            $0.minimumLineSpacing = 4.adjustedWidth
+        }
+        
+        completeButton.do {
+            $0.backgroundColor = .black
+            $0.layer.borderColor = UIColor.grayscales700.cgColor
+            $0.layer.borderWidth = 1
+            $0.layer.cornerRadius = 24.adjustedHeight
+            $0.titleLabel?.font = .uiBodyMedium
+            $0.setTitleColor(.semanticStatusRed500, for: .normal)
+            $0.setTitle(StringLiterals.Profile.WithdrawalReason.complete, for: .normal)
+        }
+    }
+    
+    override func setLayout() {
+        let statusBarHeight = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first?
+            .statusBarManager?
+            .statusBarFrame.height ?? 20
+        
+        self.addSubviews(withdrawalNavigationBarView,
+                         scrollView,
+                         completeButton)
+        
+        scrollView.addSubviews(titleLabel,
+                         reasonCollectionView)
+        
+        withdrawalNavigationBarView.snp.makeConstraints {
+            $0.top.equalTo(self.safeAreaInsets).offset(statusBarHeight)
+            $0.width.equalToSuperview()
+            $0.height.equalTo(48.adjustedHeight)
+        }
+        
+        scrollView.snp.makeConstraints {
+            $0.top.equalTo(withdrawalNavigationBarView.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(39.adjustedHeight)
+            $0.centerX.equalToSuperview()
+        }
+        
+        reasonCollectionView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(20.adjustedHeight)
+            $0.leading.trailing.equalToSuperview().inset(34.adjustedWidth)
+            $0.height.equalTo(476.adjustedHeight)
+        }
+        
+        completeButton.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(16.adjustedWidth)
+            $0.height.equalTo(48.adjustedHeight)
+            $0.width.equalTo(343.adjustedWidth)
+            $0.bottom.equalToSuperview().inset(34.adjustedHeight)
+        }
+    }
+}
 
+extension WithdrawalReasonView: UICollectionViewDelegate { }
+extension WithdrawalReasonView: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return reasonList.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ReasonCollectionViewCell.identifier,
+                                                            for: indexPath) as? ReasonCollectionViewCell else {return UICollectionViewCell()}
+        cell.descriptionLabel.text = reasonList[indexPath.row]
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ReasonCollectionViewCell.identifier,
+                                                            for: indexPath) as? ReasonCollectionViewCell else { return }
+        cell.isReasonSelected = true
+//        if selectedIndex == indexPath.row {
+//            
+//        }
+    }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
@@ -147,6 +147,9 @@ extension WithdrawalReasonView: UICollectionViewDataSource {
             cell.setTextView(isEtc: true)
             cell.etcTextView.isUserInteractionEnabled = true
             cell.etcTextView.delegate = self
+            cell.etcTextView.text = self.etcReason.isEmpty ? StringLiterals.Profile.WithdrawalReason.etcReason : self.etcReason
+            cell.etcTextView.textColor = self.etcReason.isEmpty ? .grayscales600 : .white
+            self.isCompleteEnabled = !self.etcReason.isEmpty
         } else {
             cell.setTextView(isEtc: false)
         }
@@ -188,10 +191,6 @@ extension WithdrawalReasonView: UITextViewDelegate {
             textView.text = nil
             textView.textColor = .white
         }
-    
-        if !self.etcReason.isEmpty {
-            textView.text = self.etcReason
-        }
     }
     
     func textViewShouldEndEditing(_ textView: UITextView) -> Bool {
@@ -203,9 +202,7 @@ extension WithdrawalReasonView: UITextViewDelegate {
         } else {
             self.isCompleteEnabled = true
             self.etcReason = textView.text
-            print(etcReason)
         }
-        
         textView.resignFirstResponder()
         return true
     }
@@ -232,8 +229,8 @@ extension WithdrawalReasonView {
     
     @objc func keyboardWillShow(_ notification: Notification) {
         if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
-            let scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: keyboardSize.height, right: 0)
-            reasonCollectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 26.adjustedHeight, right: 0)
+            let scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: keyboardSize.height - 26.adjustedHeight, right: 0)
+            reasonCollectionView.contentInset = scrollIndicatorInsets
             reasonCollectionView.scrollIndicatorInsets = scrollIndicatorInsets
         }
         let indexPath = IndexPath(item: self.reasonList.count - 1, section: 0)
@@ -245,6 +242,3 @@ extension WithdrawalReasonView {
         reasonCollectionView.scrollIndicatorInsets = .zero
     }
 }
-
-// TODO: 플레이스 홀더 오류.. 수정
-// TODO: 텍스트뷰 선택 후 스크롤 범위 확인

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
@@ -1,0 +1,20 @@
+//
+//  WithdrawalReasonView.swift
+//  YELLO-iOS
+//
+//  Created by 정채은 on 1/23/24.
+//
+
+import UIKit
+
+class WithdrawalReasonView: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
@@ -147,7 +147,6 @@ extension WithdrawalReasonView: UICollectionViewDataSource {
             cell.setTextView(isEtc: true)
             cell.etcTextView.isUserInteractionEnabled = true
             cell.etcTextView.delegate = self
-            self.hideKeyboardWhenTappedAround()
         } else {
             cell.setTextView(isEtc: false)
         }
@@ -184,6 +183,7 @@ extension WithdrawalReasonView: UICollectionViewDelegateFlowLayout {
 
 extension WithdrawalReasonView: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
+        hideKeyboardWhenTappedAround()
         if textView.text == StringLiterals.Profile.WithdrawalReason.etcReason {
             textView.text = nil
             textView.textColor = .white
@@ -247,3 +247,4 @@ extension WithdrawalReasonView {
 }
 
 // TODO: 플레이스 홀더 오류.. 수정
+// TODO: 텍스트뷰 선택 후 스크롤 범위 확인

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
@@ -45,7 +45,8 @@ final class WithdrawalReasonView: BaseView {
         
         reasonCollectionView.do {
             $0.backgroundColor = .clear
-            $0.isHidden = false
+            $0.showsVerticalScrollIndicator = false
+            $0.showsHorizontalScrollIndicator = false
             $0.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 26.adjustedHeight, right: 0)
         }
         
@@ -126,6 +127,7 @@ extension WithdrawalReasonView: UICollectionViewDataSource {
         } else {
             cell.setTextView(isEtc: false)
         }
+        cell.isUserInteractionEnabled = !cell.isReasonSelected
         return cell
     }
     

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
@@ -1,4 +1,3 @@
-
 //
 //  WithdrawalReasonView.swift
 //  YELLO-iOS
@@ -42,6 +41,7 @@ final class WithdrawalReasonView: BaseView {
     }
     
     override func setStyle() {
+        hideKeyboardWhenTappedAround()
         self.backgroundColor = .black
         
         withdrawalNavigationBarView.do {
@@ -104,6 +104,11 @@ final class WithdrawalReasonView: BaseView {
             $0.width.equalTo(343.adjustedWidth)
             $0.bottom.equalToSuperview().inset(34.adjustedHeight)
         }
+    }
+    
+    func setNotificationCenter() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
     func setCompleteButton(isEnabled: Bool) {
@@ -169,7 +174,7 @@ extension WithdrawalReasonView: UICollectionViewDelegateFlowLayout {
         }
     }
 }
-//
+
 extension WithdrawalReasonView: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         if textView.text == StringLiterals.Profile.WithdrawalReason.etcReason {
@@ -180,4 +185,49 @@ extension WithdrawalReasonView: UITextViewDelegate {
             textView.textColor = .grayscales600
         }
     }
+    
+    func textViewShouldEndEditing(_ textView: UITextView) -> Bool {
+        textView.resignFirstResponder()
+        return true
+    }
+    
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        let maxCharacterCount = 30
+        let currentText = textView.text ?? ""
+        let newText = (currentText as NSString).replacingCharacters(in: range, with: text)
+        return newText.count <= maxCharacterCount
+    }
 }
+
+extension WithdrawalReasonView {
+    func hideKeyboardWhenTappedAround() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tap.cancelsTouchesInView = false
+        self.addGestureRecognizer(tap)
+    }
+    
+    @objc func dismissKeyboard() {
+        self.endEditing(true)
+    }
+    
+    @objc func keyboardWillShow(_ notification: Notification) {
+        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+            reasonCollectionView.snp.updateConstraints {
+                $0.bottom.equalToSuperview().inset(26.adjustedHeight + keyboardSize.height)
+            }
+            
+            let indexPath = IndexPath(item: self.reasonList.count - 1, section: 0)
+            reasonCollectionView.scrollToItem(at: indexPath, at: .bottom, animated: true)
+        }
+    }
+
+    @objc func keyboardWillHide(_ notification: Notification) {
+        reasonCollectionView.snp.updateConstraints {
+            $0.bottom.equalToSuperview().inset(82.adjustedHeight)
+        }
+    }
+}
+
+// TODO: 플레이스 홀더 수정
+// TODO: 스크롤 수정
+// TODO: Return 버튼 누르면 키보드 사라지도록

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
@@ -12,14 +12,14 @@ import Then
 
 final class WithdrawalReasonView: BaseView {
 
-    let reasonList: [String] = [StringLiterals.Profile.WithdrawalReason.nobody,
-                                StringLiterals.Profile.WithdrawalReason.expensive,
-                                StringLiterals.Profile.WithdrawalReason.error,
-                                StringLiterals.Profile.WithdrawalReason.notFunny,
-                                StringLiterals.Profile.WithdrawalReason.lessPoint,
-                                StringLiterals.Profile.WithdrawalReason.delete,
-                                StringLiterals.Profile.WithdrawalReason.otherApp,
-                                StringLiterals.Profile.WithdrawalReason.etc]
+    let reasonList = [StringLiterals.Profile.WithdrawalReason.nobody,
+                      StringLiterals.Profile.WithdrawalReason.expensive,
+                      StringLiterals.Profile.WithdrawalReason.error,
+                      StringLiterals.Profile.WithdrawalReason.notFunny,
+                      StringLiterals.Profile.WithdrawalReason.lessPoint,
+                      StringLiterals.Profile.WithdrawalReason.delete,
+                      StringLiterals.Profile.WithdrawalReason.otherApp,
+                      StringLiterals.Profile.WithdrawalReason.etc]    
     var selectedIndex = -1
     
     let withdrawalNavigationBarView = SettingNavigationBarView()
@@ -29,25 +29,22 @@ final class WithdrawalReasonView: BaseView {
     let reasonFlowLayout = UICollectionViewFlowLayout()
     let completeButton = UIButton()
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        setCollectionView()
-    }
-    
-    private func setCollectionView() {
+    func setCollectionView() {
         reasonCollectionView.register(ReasonCollectionViewCell.self, forCellWithReuseIdentifier: ReasonCollectionViewCell.identifier)
         reasonCollectionView.delegate = self
         reasonCollectionView.dataSource = self
     }
     
     override func setStyle() {
+        self.backgroundColor = .black
+        
         withdrawalNavigationBarView.do {
             $0.titleLabel.setTextWithLineHeight(text: StringLiterals.Profile.WithdrawalCheck.withdrawal, lineHeight: 24.adjustedHeight)
             $0.backgroundColor = .black
         }
         
         scrollView.do {
-            $0.backgroundColor = .black
+            $0.backgroundColor = .clear
         }
         
         titleLabel.do {
@@ -60,11 +57,13 @@ final class WithdrawalReasonView: BaseView {
             $0.backgroundColor = .clear
             $0.showsVerticalScrollIndicator = false
             $0.isScrollEnabled = false
+            $0.isHidden = false
         }
         
         reasonFlowLayout.do {
-            $0.scrollDirection = .horizontal
+            $0.scrollDirection = .vertical
             $0.minimumLineSpacing = 4.adjustedWidth
+            $0.itemSize = CGSize(width: UIScreen.main.bounds.width - 68.adjustedWidth, height: 56.adjustedHeight)
         }
         
         completeButton.do {
@@ -90,7 +89,7 @@ final class WithdrawalReasonView: BaseView {
                          completeButton)
         
         scrollView.addSubviews(titleLabel,
-                         reasonCollectionView)
+                               reasonCollectionView)
         
         withdrawalNavigationBarView.snp.makeConstraints {
             $0.top.equalTo(self.safeAreaInsets).offset(statusBarHeight)
@@ -110,8 +109,10 @@ final class WithdrawalReasonView: BaseView {
         
         reasonCollectionView.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(20.adjustedHeight)
-            $0.leading.trailing.equalToSuperview().inset(34.adjustedWidth)
+            $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(476.adjustedHeight)
+            $0.width.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(108.adjustedHeight)
         }
         
         completeButton.snp.makeConstraints {
@@ -131,18 +132,14 @@ extension WithdrawalReasonView: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ReasonCollectionViewCell.identifier,
-                                                            for: indexPath) as? ReasonCollectionViewCell else {return UICollectionViewCell()}
-        cell.descriptionLabel.text = reasonList[indexPath.row]
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ReasonCollectionViewCell.identifier, for: indexPath) as? ReasonCollectionViewCell else { return UICollectionViewCell() }
+        cell.dataBind(data: reasonList[indexPath.row])
+        cell.isReasonSelected = (indexPath.row == selectedIndex)
         return cell
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ReasonCollectionViewCell.identifier,
-                                                            for: indexPath) as? ReasonCollectionViewCell else { return }
-        cell.isReasonSelected = true
-//        if selectedIndex == indexPath.row {
-//            
-//        }
+        selectedIndex = indexPath.row
+        reasonCollectionView.reloadData()
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
@@ -1,3 +1,4 @@
+
 //
 //  WithdrawalReasonView.swift
 //  YELLO-iOS
@@ -19,7 +20,7 @@ final class WithdrawalReasonView: BaseView {
                       StringLiterals.Profile.WithdrawalReason.lessPoint,
                       StringLiterals.Profile.WithdrawalReason.delete,
                       StringLiterals.Profile.WithdrawalReason.otherApp,
-                      StringLiterals.Profile.WithdrawalReason.etc]    
+                      StringLiterals.Profile.WithdrawalReason.etc]
     var selectedIndex = -1
     var isCompleteEnabled = false {
         didSet {
@@ -138,10 +139,11 @@ extension WithdrawalReasonView: UICollectionViewDataSource {
         cell.isReasonSelected = (indexPath.row == selectedIndex)
         if selectedIndex == 7 && indexPath.row == 7 {
             cell.setTextView(isEtc: true)
+            cell.etcTextView.isUserInteractionEnabled = true
+            cell.etcTextView.delegate = self
         } else {
             cell.setTextView(isEtc: false)
         }
-        cell.isUserInteractionEnabled = !cell.isReasonSelected
         return cell
     }
     
@@ -164,6 +166,18 @@ extension WithdrawalReasonView: UICollectionViewDelegateFlowLayout {
             return CGSize(width: UIScreen.main.bounds.width - 68.adjustedWidth, height: 141.adjustedHeight)
         } else {
             return CGSize(width: UIScreen.main.bounds.width - 68.adjustedWidth, height: 56.adjustedHeight)
+        }
+    }
+}
+//
+extension WithdrawalReasonView: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.text == StringLiterals.Profile.WithdrawalReason.etcReason {
+            textView.text = nil
+            textView.textColor = .white
+        } else if textView.text.isEmpty {
+            textView.text = StringLiterals.Profile.WithdrawalReason.etcReason
+            textView.textColor = .grayscales600
         }
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
@@ -26,6 +26,7 @@ final class WithdrawalReasonView: BaseView {
             self.setCompleteButton(isEnabled: isCompleteEnabled)
         }
     }
+    var etcReason: String = ""
     
     let withdrawalNavigationBarView = SettingNavigationBarView()
     let reasonHeaderView = ReasonHeaderView()
@@ -158,10 +159,11 @@ extension WithdrawalReasonView: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         print(indexPath.row)
-        // 추후 사유 빈칸일 때 제외로 수정
-        isCompleteEnabled = true
-        selectedIndex = indexPath.row
-        reasonCollectionView.reloadData()
+        if indexPath.row != selectedIndex {
+            selectedIndex = indexPath.row
+            isCompleteEnabled = selectedIndex != 7 ? true : false
+            reasonCollectionView.reloadData()
+        }
     }
 }
 
@@ -180,13 +182,25 @@ extension WithdrawalReasonView: UITextViewDelegate {
         if textView.text == StringLiterals.Profile.WithdrawalReason.etcReason {
             textView.text = nil
             textView.textColor = .white
-        } else if textView.text.isEmpty {
-            textView.text = StringLiterals.Profile.WithdrawalReason.etcReason
-            textView.textColor = .grayscales600
+        }
+    
+        if !self.etcReason.isEmpty {
+            textView.text = self.etcReason
         }
     }
     
     func textViewShouldEndEditing(_ textView: UITextView) -> Bool {
+        if textView.text.isEmpty || textView.text == "" || textView.text == StringLiterals.Profile.WithdrawalReason.etcReason {
+            self.isCompleteEnabled = false
+            textView.text = StringLiterals.Profile.WithdrawalReason.etcReason
+            textView.textColor = .grayscales600
+            self.etcReason = ""
+        } else {
+            self.isCompleteEnabled = true
+            self.etcReason = textView.text
+            print(etcReason)
+        }
+        
         textView.resignFirstResponder()
         return true
     }
@@ -215,9 +229,8 @@ extension WithdrawalReasonView {
             reasonCollectionView.snp.updateConstraints {
                 $0.bottom.equalToSuperview().inset(26.adjustedHeight + keyboardSize.height)
             }
-            
             let indexPath = IndexPath(item: self.reasonList.count - 1, section: 0)
-            reasonCollectionView.scrollToItem(at: indexPath, at: .bottom, animated: true)
+            reasonCollectionView.scrollToItem(at: indexPath, at: .top, animated: true)
         }
     }
 
@@ -228,6 +241,5 @@ extension WithdrawalReasonView {
     }
 }
 
-// TODO: 플레이스 홀더 수정
 // TODO: 스크롤 수정
 // TODO: Return 버튼 누르면 키보드 사라지도록

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/View/WithdrawalReasonView.swift
@@ -23,14 +23,14 @@ final class WithdrawalReasonView: BaseView {
     var selectedIndex = -1
     
     let withdrawalNavigationBarView = SettingNavigationBarView()
-    private let scrollView = UIScrollView()
-    private let titleLabel = UILabel()
+    let reasonHeaderView = ReasonHeaderView()
     lazy var reasonCollectionView = UICollectionView(frame: .zero, collectionViewLayout: reasonFlowLayout)
     let reasonFlowLayout = UICollectionViewFlowLayout()
     let completeButton = UIButton()
     
     func setCollectionView() {
         reasonCollectionView.register(ReasonCollectionViewCell.self, forCellWithReuseIdentifier: ReasonCollectionViewCell.identifier)
+        reasonCollectionView.register(ReasonHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: ReasonHeaderView.identifier)
         reasonCollectionView.delegate = self
         reasonCollectionView.dataSource = self
     }
@@ -43,27 +43,15 @@ final class WithdrawalReasonView: BaseView {
             $0.backgroundColor = .black
         }
         
-        scrollView.do {
-            $0.backgroundColor = .clear
-        }
-        
-        titleLabel.do {
-            $0.setTextWithLineHeight(text: StringLiterals.Profile.WithdrawalReason.title, lineHeight: 32.adjustedHeight)
-            $0.font = .uiHeadline01
-            $0.textColor = .white
-        }
-        
         reasonCollectionView.do {
             $0.backgroundColor = .clear
-            $0.showsVerticalScrollIndicator = false
-            $0.isScrollEnabled = false
             $0.isHidden = false
+            $0.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 26.adjustedHeight, right: 0)
         }
         
         reasonFlowLayout.do {
             $0.scrollDirection = .vertical
             $0.minimumLineSpacing = 4.adjustedWidth
-            $0.itemSize = CGSize(width: UIScreen.main.bounds.width - 68.adjustedWidth, height: 56.adjustedHeight)
         }
         
         completeButton.do {
@@ -85,11 +73,8 @@ final class WithdrawalReasonView: BaseView {
             .statusBarFrame.height ?? 20
         
         self.addSubviews(withdrawalNavigationBarView,
-                         scrollView,
+                         reasonCollectionView,
                          completeButton)
-        
-        scrollView.addSubviews(titleLabel,
-                               reasonCollectionView)
         
         withdrawalNavigationBarView.snp.makeConstraints {
             $0.top.equalTo(self.safeAreaInsets).offset(statusBarHeight)
@@ -97,22 +82,11 @@ final class WithdrawalReasonView: BaseView {
             $0.height.equalTo(48.adjustedHeight)
         }
         
-        scrollView.snp.makeConstraints {
-            $0.top.equalTo(withdrawalNavigationBarView.snp.bottom)
-            $0.leading.trailing.bottom.equalToSuperview()
-        }
-        
-        titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(39.adjustedHeight)
-            $0.centerX.equalToSuperview()
-        }
-        
         reasonCollectionView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(20.adjustedHeight)
+            $0.top.equalTo(withdrawalNavigationBarView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(476.adjustedHeight)
             $0.width.equalToSuperview()
-            $0.bottom.equalToSuperview().inset(108.adjustedHeight)
+            $0.bottom.equalToSuperview().inset(82.adjustedHeight)
         }
         
         completeButton.snp.makeConstraints {
@@ -131,15 +105,46 @@ extension WithdrawalReasonView: UICollectionViewDataSource {
         return reasonList.count
     }
     
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        if kind == UICollectionView.elementKindSectionHeader {
+            guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: ReasonHeaderView.identifier, for: indexPath) as? ReasonHeaderView else {
+                return ReasonHeaderView()
+            }
+            
+            header.setUI()
+            return header
+        }
+        return UICollectionReusableView()
+    }
+    
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ReasonCollectionViewCell.identifier, for: indexPath) as? ReasonCollectionViewCell else { return UICollectionViewCell() }
         cell.dataBind(data: reasonList[indexPath.row])
         cell.isReasonSelected = (indexPath.row == selectedIndex)
+        if selectedIndex == 7 && indexPath.row == 7 {
+            cell.setTextView(isEtc: true)
+        } else {
+            cell.setTextView(isEtc: false)
+        }
         return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+        return CGSize(width: UIScreen.main.bounds.width, height: 91.adjustedHeight)
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         selectedIndex = indexPath.row
         reasonCollectionView.reloadData()
+    }
+}
+
+extension WithdrawalReasonView: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        if selectedIndex == 7 && indexPath.row == 7 {
+            return CGSize(width: UIScreen.main.bounds.width - 68.adjustedWidth, height: 141.adjustedHeight)
+        } else {
+            return CGSize(width: UIScreen.main.bounds.width - 68.adjustedWidth, height: 56.adjustedHeight)
+        }
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/ViewController/WithdrawalCheckViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/ViewController/WithdrawalCheckViewController.swift
@@ -17,6 +17,11 @@ final class WithdrawalCheckViewController: BaseViewController {
     private let withdrawalCheckView = WithdrawalCheckView()
     
     // MARK: - Function
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setAddTarget()
+    }
+    
     // MARK: - Layout
     override func setStyle() {
         navigationController?.setNavigationBarHidden(true, animated: true)
@@ -32,6 +37,15 @@ final class WithdrawalCheckViewController: BaseViewController {
         withdrawalCheckView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
+    }
+    
+    private func setAddTarget() {
+        withdrawalCheckView.withdrawalButton.addTarget(self, action: #selector(withdrawalButtonTapped), for: .touchUpInside)
+    }
+    
+    @objc func withdrawalButtonTapped() {
+        let withdrawalReasonViewController = WithdrawalReasonViewController()
+        navigationController?.pushViewController(withdrawalReasonViewController, animated: true)
     }
 }
 

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/ViewController/WithdrawalReasonViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/ViewController/WithdrawalReasonViewController.swift
@@ -7,23 +7,49 @@
 
 import UIKit
 
-class WithdrawalReasonViewController: UIViewController {
+import Amplitude
+import SnapKit
+import Then
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+final class WithdrawalReasonViewController: BaseViewController {
+    
+    private let withdrawalReasonView = WithdrawalReasonView()
+    
+    override func setStyle() {
+        withdrawalReasonView.withdrawalNavigationBarView.handleBackButtonDelegate = self
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func setLayout() {
+        view.addSubviews(withdrawalReasonView)
+        
+        withdrawalReasonView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
     }
-    */
+}
 
+extension WithdrawalReasonViewController {
+    // MARK: Objc Function
+    @objc func showAlert() {
+        Amplitude.instance().logEvent("click_profile_withdrawal", withEventProperties: ["withdrawal_button":"withdrawal3"])
+//        guard let viewController = UIApplication.shared.keyWindow?.rootViewController else { return }
+//        
+//        if let withdrawalAlertView = withdrawalAlertView {
+//            withdrawalAlertView.removeFromSuperview()
+//        }
+//        
+//        withdrawalAlertView = WithdrawalAlertView()
+//        withdrawalAlertView?.frame = viewController.view.bounds
+//        withdrawalAlertView?.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+//        
+//        viewController.view.addSubview(withdrawalAlertView!)
+//        
+    }
+}
+
+// MARK: HandleBackButtonDelegate
+extension WithdrawalReasonViewController: HandleBackButtonDelegate {
+    func popView() {
+        self.navigationController?.popViewController(animated: true)
+    }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/ViewController/WithdrawalReasonViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/ViewController/WithdrawalReasonViewController.swift
@@ -42,7 +42,7 @@ final class WithdrawalReasonViewController: BaseViewController {
 extension WithdrawalReasonViewController {
     // MARK: Objc Function
     @objc func showAlert() {
-//        Amplitude.instance().logEvent("click_profile_withdrawal", withEventProperties: ["withdrawal_button":"withdrawal3"])
+        Amplitude.instance().logEvent("click_profile_withdrawal", withEventProperties: ["withdrawal_button":"withdrawal3"])
         
         let withdrawalAlertView = WithdrawalAlertView()
         self.view.addSubview(withdrawalAlertView)

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/ViewController/WithdrawalReasonViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/ViewController/WithdrawalReasonViewController.swift
@@ -1,0 +1,29 @@
+//
+//  WithdrawalReasonViewController.swift
+//  YELLO-iOS
+//
+//  Created by 정채은 on 1/23/24.
+//
+
+import UIKit
+
+class WithdrawalReasonViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/ViewController/WithdrawalReasonViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/ViewController/WithdrawalReasonViewController.swift
@@ -15,6 +15,12 @@ final class WithdrawalReasonViewController: BaseViewController {
     
     private let withdrawalReasonView = WithdrawalReasonView()
     
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        withdrawalReasonView.setCollectionView()
+        self.setAddTarget()
+    }
+    
     override func setStyle() {
         withdrawalReasonView.withdrawalNavigationBarView.handleBackButtonDelegate = self
     }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/ViewController/WithdrawalReasonViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/ViewController/WithdrawalReasonViewController.swift
@@ -32,24 +32,22 @@ final class WithdrawalReasonViewController: BaseViewController {
             $0.edges.equalToSuperview()
         }
     }
+    
+    private func setAddTarget() {
+        withdrawalReasonView.completeButton.addTarget(self, action: #selector(showAlert), for: .touchUpInside)
+    }
 }
 
 extension WithdrawalReasonViewController {
     // MARK: Objc Function
     @objc func showAlert() {
-        Amplitude.instance().logEvent("click_profile_withdrawal", withEventProperties: ["withdrawal_button":"withdrawal3"])
-//        guard let viewController = UIApplication.shared.keyWindow?.rootViewController else { return }
-//        
-//        if let withdrawalAlertView = withdrawalAlertView {
-//            withdrawalAlertView.removeFromSuperview()
-//        }
-//        
-//        withdrawalAlertView = WithdrawalAlertView()
-//        withdrawalAlertView?.frame = viewController.view.bounds
-//        withdrawalAlertView?.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-//        
-//        viewController.view.addSubview(withdrawalAlertView!)
-//        
+//        Amplitude.instance().logEvent("click_profile_withdrawal", withEventProperties: ["withdrawal_button":"withdrawal3"])
+        
+        let withdrawalAlertView = WithdrawalAlertView()
+        self.view.addSubview(withdrawalAlertView)
+        withdrawalAlertView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
     }
 }
 

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/ViewController/WithdrawalReasonViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Setting/Withdrawal/ViewController/WithdrawalReasonViewController.swift
@@ -18,6 +18,7 @@ final class WithdrawalReasonViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         withdrawalReasonView.setCollectionView()
+        withdrawalReasonView.setNotificationCenter()
         self.setAddTarget()
     }
     


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 3차 스프린트 1순위인 탈퇴 사유 부분 구현했습니다.
- 단일 선택 가능하도록, 했고 마지막 기타 부분 선택했을 때 이유 작성하고 다른 선택지 선택 후 다시 기타로 돌아왔을 때 저장되어 있을 수 있도록 구현했습니다.
- 아직 API는 개발 안된 것 같아서 network 부분은 아직 구현 안했습니다!
<!--
```
작성한 코드가 있다면 여기에 주석을 제거하고 적어주세요!
```
-->


## 📌 PR Point!
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 키보드 올라오는 로직 너무.. 정신 없어서 이 부분 위주로 확인해주세요..


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 12pro  |   ![ezgif-4-de8ca61941](https://github.com/team-yello/YELLO-iOS/assets/109775321/fb9b9a60-256f-4109-8ba6-0932530010e2)   |


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #296 