### PR TITLE
Feat [#319] 프로필 공지 배너 구현

### DIFF
--- a/YELLO-iOS/YELLO-iOS/Global/Literals/String.swift
+++ b/YELLO-iOS/YELLO-iOS/Global/Literals/String.swift
@@ -362,7 +362,7 @@ enum StringLiterals {
         }
         
         enum Setting {
-            static let setting = "프로필 관리"
+            static let setting = "설정"
             static let center = "고객센터"
             static let privacy = "개인정보 처리방침"
             static let service = "이용약관"

--- a/YELLO-iOS/YELLO-iOS/Global/Literals/String.swift
+++ b/YELLO-iOS/YELLO-iOS/Global/Literals/String.swift
@@ -309,7 +309,7 @@ enum StringLiterals {
     enum Profile {
         enum NavigationBar {
             static let profile = "프로필"
-            static let setting = "관리"
+            static let setting = "설정"
         }
         
         enum Count {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/Base/OnboardingViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/Base/OnboardingViewController.swift
@@ -89,7 +89,7 @@ class OnboardingBaseViewController: UIViewController {
             $0.addArrangedSubviews(skipButton, nextButton)
             $0.axis = .vertical
             $0.alignment = .center
-            $0.spacing = 14
+            $0.spacing = 10.adjustedHeight
         }
         
         skipButton.isHidden = !(isSkipable)

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Edit/View/EditProfileHeaderView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Edit/View/EditProfileHeaderView.swift
@@ -38,7 +38,6 @@ final class EditProfileHeaderView: UITableViewHeaderFooterView {
     
     private func setStyle() {
         profileImageView.do {
-            print("🥰🥰🥰🥰\(UserManager.shared.profileImage)")
             if UserManager.shared.profileImage == StringLiterals.Profile.EditProfile.KakaoDefaultProfileURL {
                 $0.image = ImageLiterals.Profile.imgDefaultProfile
             } else {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/InfoView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/InfoView.swift
@@ -10,12 +10,13 @@ import UIKit
 import Then
 import SnapKit
 
-class InfoView: UIView {
+final class InfoView: UIView {
     
     // MARK: - Variables
     // MARK: Component
     let infoLabel = UILabel()
     let descriptionLabel = UILabel()
+    let stackView = UIStackView()
     
     // MARK: - Function
     // MARK: LifeCycle
@@ -43,31 +44,31 @@ class InfoView: UIView {
         infoLabel.do {
             $0.font = .uiHeadline02
             $0.textColor = .white
-            $0.setTextWithLineHeight(text: $0.text, lineHeight: 30.adjustedHeight)
         }
         
         descriptionLabel.do {
             $0.font = .uiLabelMedium
             $0.textColor = .grayscales500
         }
+        
+        stackView.do {
+            $0.addArrangedSubviews(infoLabel, descriptionLabel)
+            $0.axis = .vertical
+            $0.alignment = .center
+        }
     }
     
     private func setLayout() {
-        self.addSubviews(infoLabel, descriptionLabel)
+        self.addSubviews(stackView)
         
         self.snp.makeConstraints {
             $0.width.equalTo(109.adjustedWidth)
             $0.height.equalTo(68.adjustedHeight)
         }
         
-        infoLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(12.adjustedHeight)
-            $0.centerX.equalToSuperview()
-        }
-        
-        descriptionLabel.snp.makeConstraints {
-            $0.top.equalTo(infoLabel.snp.bottom)
-            $0.centerX.equalToSuperview()
+        stackView.snp.makeConstraints {
+            $0.height.equalTo(45.adjustedHeight)
+            $0.center.equalToSuperview()
         }
     }
     

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileHeaderView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileHeaderView.swift
@@ -59,7 +59,7 @@ extension MyProfileHeaderView {
         }
         
         friendCountView.snp.makeConstraints {
-            $0.top.equalTo(myProfileView.snp.bottom).offset(40.adjustedHeight)
+            $0.top.equalTo(myProfileView.snp.bottom).offset(12.adjustedHeight)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalToSuperview().inset(8.adjustedHeight)
         }
@@ -72,7 +72,6 @@ extension MyProfileHeaderView {
             case .success(let data):
                 guard let data = data.data else { return }
                 updateUserInfo(data)
-                print(data.profileImageURL)
                 if data.profileImageURL != StringLiterals.Recommending.Title.defaultProfileImageLink &&
                     data.profileImageURL != StringLiterals.Profile.EditProfile.KakaoDefaultProfileURL {
                     self.myProfileView.mainProfileView.profileImageView.kfSetImage(url: data.profileImageURL)

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileHeaderView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileHeaderView.swift
@@ -56,7 +56,6 @@ extension MyProfileHeaderView {
         myProfileView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(12.adjustedHeight)
             $0.leading.trailing.equalToSuperview()
-            if myProfileView.isAvailable { $0.height.equalTo(317.adjustedHeight)}
         }
         
         friendCountView.snp.makeConstraints {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileHeaderView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileHeaderView.swift
@@ -56,6 +56,7 @@ extension MyProfileHeaderView {
         myProfileView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(12.adjustedHeight)
             $0.leading.trailing.equalToSuperview()
+            if myProfileView.isAvailable { $0.height.equalTo(317.adjustedHeight)}
         }
         
         friendCountView.snp.makeConstraints {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileView.swift
@@ -60,6 +60,11 @@ final class MyProfileView: UIView {
         }
     }
     
+    // MARK: Objc Function
+    @objc func tapNotification() {
+        let url = URL(string: redirectionURL)!
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+    }
 }
 
 // MARK: - extension

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileView.swift
@@ -52,7 +52,6 @@ final class MyProfileView: UIView {
     func updateNotification() {
         self.notificationImageView.isHidden = !isAvailable
         height = isAvailable ? 57.adjustedHeight : 0
-        
         notificationImageView.snp.remakeConstraints {
             $0.height.equalTo(height)
             $0.leading.trailing.equalToSuperview()

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileView.swift
@@ -15,7 +15,14 @@ final class MyProfileView: UIView {
     
     // MARK: - Variables
     // MARK: Property
-    var redirectionURL: String = ""
+    var height = 57.adjustedHeight
+    var isAvailable = false {
+        didSet {
+            self.notificationImageView.isHidden = !isAvailable
+            height = isAvailable ? 57.adjustedHeight : 0.adjustedHeight
+            setUI()
+        }
+    }
     
     // MARK: Component
     let mainProfileView = MainProfileView()
@@ -36,34 +43,12 @@ final class MyProfileView: UIView {
     // MARK: LifeCycle
     override init(frame: CGRect) {
         super.init(frame: frame)
-        loadProfileNoti()
         setUI()
     }
     
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    // MARK: Custom Function
-    func loadProfileNoti() {
-        NetworkService.shared.notificationService.userNotification(typeName: "PROFILE-BANNER") { result in
-            switch result {
-            case .success(let data):
-                if let data = data.data {
-                    self.notificationImageView.kfSetImage(url: data.imageUrl)
-                    self.redirectionURL = data.redirectUrl
-                }
-            default:
-                print("프로필 공지사항")
-            }
-        }
-    }
-    
-    // MARK: Objc Function
-    @objc func tapNotification() {
-        let url = URL(string: redirectionURL)!
-        UIApplication.shared.open(url, options: [:], completionHandler: nil)
     }
 }
 
@@ -122,11 +107,8 @@ extension MyProfileView {
         }
         
         notificationImageView.do {
-            let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapNotification))
             $0.makeCornerRound(radius: 12.adjusted)
-            $0.addGestureRecognizer(tapGesture)
-            $0.isUserInteractionEnabled = true
-            $0.backgroundColor = .red
+            $0.contentMode = .scaleAspectFill
         }
     }
     
@@ -172,9 +154,9 @@ extension MyProfileView {
         
         notificationImageView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
-            $0.top.equalTo(shopButton.snp.bottom).offset(10.adjusted)
+            $0.top.equalTo(shopBackgroundView.snp.bottom).offset(10.adjusted)
             $0.bottom.equalToSuperview()
-            $0.height.equalTo(57.adjusted)
+            $0.height.equalTo(height)
         }
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileView.swift
@@ -117,7 +117,7 @@ extension MyProfileView {
         
         notificationImageView.do {
             $0.makeCornerRound(radius: 12.adjusted)
-            $0.contentMode = .scaleAspectFill
+            $0.contentMode = .scaleAspectFit
         }
     }
     

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileView.swift
@@ -14,6 +14,9 @@ import Then
 final class MyProfileView: UIView {
     
     // MARK: - Variables
+    // MARK: Property
+    var redirectionURL: String = ""
+    
     // MARK: Component
     let mainProfileView = MainProfileView()
     
@@ -26,6 +29,8 @@ final class MyProfileView: UIView {
     lazy var shopButton = UIButton(frame: CGRect(x: 0, y: 0, width: 0, height: 44.adjustedHeight))
     let shopBackgroundView = UIView(frame: CGRect(x: 0, y: 0, width: 343.adjustedWidth, height: 48.adjustedHeight))
     let saleLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 0, height: 22.adjustedHeight))
+    
+    let notificationImageView = UIImageView()
     
     // MARK: - Function
     // MARK: LifeCycle
@@ -93,6 +98,14 @@ extension MyProfileView {
             $0.makeCornerRound(radius: 4.adjustedHeight)
             $0.textAlignment = .center
         }
+        
+        notificationImageView.do {
+            let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapNotification))
+            $0.makeCornerRound(radius: 12.adjusted)
+            $0.addGestureRecognizer(tapGesture)
+            $0.isUserInteractionEnabled = true
+            $0.backgroundColor = .red
+        }
     }
     
     private func setLayout() {
@@ -100,12 +113,13 @@ extension MyProfileView {
             mainProfileView,
             infoStackView,
             shopBackgroundView,
-            saleLabel)
+            saleLabel,
+            notificationImageView)
         
         shopBackgroundView.addSubviews(shopButton)
         
         mainProfileView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(12.adjustedHeight)
+            $0.top.equalToSuperview()
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(88.adjustedHeight)
         }
@@ -119,7 +133,6 @@ extension MyProfileView {
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(48.adjustedHeight)
             $0.top.equalTo(infoStackView.snp.bottom).offset(12.adjustedHeight)
-            $0.bottom.equalToSuperview()
         }
         
         shopButton.snp.makeConstraints {
@@ -133,6 +146,13 @@ extension MyProfileView {
             $0.width.equalTo(48.adjustedWidth)
             $0.trailing.equalTo(shopBackgroundView).inset(6.adjustedWidth)
             $0.top.equalTo(infoStackView.snp.bottom).offset(4.adjustedHeight)
+        }
+        
+        notificationImageView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.top.equalTo(shopButton.snp.bottom).offset(10.adjusted)
+            $0.bottom.equalToSuperview()
+            $0.height.equalTo(57.adjusted)
         }
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileView.swift
@@ -18,9 +18,7 @@ final class MyProfileView: UIView {
     var height = 57.adjustedHeight
     var isAvailable = false {
         didSet {
-            self.notificationImageView.isHidden = !isAvailable
-            height = isAvailable ? 57.adjustedHeight : 0.adjustedHeight
-            setUI()
+            updateNotification()
         }
     }
     
@@ -49,6 +47,18 @@ final class MyProfileView: UIView {
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    func updateNotification() {
+        self.notificationImageView.isHidden = !isAvailable
+        height = isAvailable ? 57.adjustedHeight : 0
+        
+        notificationImageView.snp.remakeConstraints {
+            $0.height.equalTo(height)
+            $0.leading.trailing.equalToSuperview()
+            $0.top.equalTo(shopBackgroundView.snp.bottom).offset(10.adjusted)
+            $0.bottom.equalToSuperview()
+        }
     }
 }
 
@@ -153,10 +163,10 @@ extension MyProfileView {
         }
         
         notificationImageView.snp.makeConstraints {
+            $0.height.equalTo(height)
             $0.leading.trailing.equalToSuperview()
             $0.top.equalTo(shopBackgroundView.snp.bottom).offset(10.adjusted)
             $0.bottom.equalToSuperview()
-            $0.height.equalTo(height)
         }
     }
 }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/MyProfileView.swift
@@ -36,6 +36,7 @@ final class MyProfileView: UIView {
     // MARK: LifeCycle
     override init(frame: CGRect) {
         super.init(frame: frame)
+        loadProfileNoti()
         setUI()
     }
     
@@ -43,6 +44,22 @@ final class MyProfileView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    // MARK: Custom Function
+    func loadProfileNoti() {
+        NetworkService.shared.notificationService.userNotification(typeName: "PROFILE-BANNER") { result in
+            switch result {
+            case .success(let data):
+                if let data = data.data {
+                    self.notificationImageView.kfSetImage(url: data.imageUrl)
+                    self.redirectionURL = data.redirectUrl
+                }
+            default:
+                print("프로필 공지사항")
+            }
+        }
+    }
+    
 }
 
 // MARK: - extension

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/ProfileView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/ProfileView.swift
@@ -37,6 +37,13 @@ final class ProfileView: UIView {
             self.myFriendTableView.reloadData()
         }
     }
+    var redirectionURL: String = ""
+    var notiBannerImageURL = ""
+    var isAvailable = false {
+        didSet {
+            self.myFriendTableView.reloadData()
+        }
+    }
     var pageCount = -1
     var myYelloCount = 0
     var profileFriendPage: Int = 0
@@ -235,6 +242,30 @@ extension ProfileView {
             }
         }
     }
+    
+    // MARK: Custom Function
+    func loadProfileNoti() {
+        NetworkService.shared.notificationService.userNotification(typeName: "PROFILE-BANNER") { result in
+            switch result {
+            case .success(let data):
+                if let data = data.data {
+                   self.isAvailable = data.isAvailable
+                    if data.isAvailable {
+                        self.notiBannerImageURL = data.imageUrl
+                        self.redirectionURL = data.redirectUrl
+                    }
+                }
+            default:
+                print("프로필 공지사항 Network Error")
+            }
+        }
+    }
+    
+    // MARK: Objc Function
+    @objc func tapNotification() {
+        let url = URL(string: redirectionURL)!
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+    }
 }
 
 // MARK: UITableViewDelegate
@@ -281,7 +312,13 @@ extension ProfileView: UITableViewDataSource {
                 view?.myProfileView.shopButton.addTarget(self, action: #selector(shopButtonTapped), for: .touchUpInside)
                 view?.myProfileView.mainProfileView.editProfileButton.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
                 view?.myProfileView.mainProfileView.isYelloPlus = self.isYelloPlus
+                
                 view?.myProfileView.mainProfileView.updateProfileView()
+                view?.myProfileView.isAvailable = self.isAvailable
+                view?.myProfileView.notificationImageView.kfSetImage(url: notiBannerImageURL)
+                let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapNotification))
+                view?.myProfileView.notificationImageView.addGestureRecognizer(tapGesture)
+                view?.myProfileView.notificationImageView.isUserInteractionEnabled = true
             }
             return view
         default:
@@ -290,7 +327,7 @@ extension ProfileView: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        return section == 0 ? 347.adjusted : 0
+        return isAvailable ? 347.adjusted : 307.adjusted
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/ProfileView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/ProfileView.swift
@@ -290,7 +290,7 @@ extension ProfileView: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        return section == 0 ? 304.adjustedHeight : 0
+        return section == 0 ? 347.adjusted : 0
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/ProfileView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/ProfileView.swift
@@ -311,14 +311,14 @@ extension ProfileView: UITableViewDataSource {
                 view?.myProfileView.mainProfileView.schoolSkeletonLabel.isHidden = true
                 view?.myProfileView.shopButton.addTarget(self, action: #selector(shopButtonTapped), for: .touchUpInside)
                 view?.myProfileView.mainProfileView.editProfileButton.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
-                view?.myProfileView.mainProfileView.isYelloPlus = self.isYelloPlus
-                
-                view?.myProfileView.mainProfileView.updateProfileView()
                 view?.myProfileView.isAvailable = self.isAvailable
+                view?.myProfileView.updateNotification()
                 view?.myProfileView.notificationImageView.kfSetImage(url: notiBannerImageURL)
                 let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapNotification))
                 view?.myProfileView.notificationImageView.addGestureRecognizer(tapGesture)
                 view?.myProfileView.notificationImageView.isUserInteractionEnabled = true
+                view?.myProfileView.mainProfileView.isYelloPlus = self.isYelloPlus
+                view?.myProfileView.mainProfileView.updateProfileView()
             }
             return view
         default:

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/ProfileView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/View/ProfileView.swift
@@ -312,7 +312,6 @@ extension ProfileView: UITableViewDataSource {
                 view?.myProfileView.shopButton.addTarget(self, action: #selector(shopButtonTapped), for: .touchUpInside)
                 view?.myProfileView.mainProfileView.editProfileButton.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
                 view?.myProfileView.isAvailable = self.isAvailable
-                view?.myProfileView.updateNotification()
                 view?.myProfileView.notificationImageView.kfSetImage(url: notiBannerImageURL)
                 let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapNotification))
                 view?.myProfileView.notificationImageView.addGestureRecognizer(tapGesture)

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/ViewController/ProfileViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Main/ViewController/ProfileViewController.swift
@@ -40,6 +40,7 @@ final class ProfileViewController: BaseViewController {
         self.tabBarController?.tabBar.items?[2].imageInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         self.profileView.myProfileHeaderView.profileUser()
         self.profileView.purchaseInfo()
+        self.profileView.loadProfileNoti()
         self.resetProfileView()
         self.paymentPlusViewController.getProducts()
     }


### PR DESCRIPTION
## ⛏ 작업 내용
공지사항 서버 통신 후 `isAvailable` 값이 `true`인 경우 프로필 배너를 구현했습니다.


## 📌 PR Point!
- `isAvailable` 값에 따라 헤더 높이 값이 변하기 때문에 아래와 같이 처리했습니다. 
``` swift
func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
        return isAvailable ? 347.adjusted : 307.adjusted
    }
```
- 마찬가지로, 공지가 없을 때 다시 레이아웃을 잡아야 하기 때문에 remake 함수를 사용했습니다. 
``` swift 
func updateNotification() {
        self.notificationImageView.isHidden = !isAvailable
        height = isAvailable ? 57.adjustedHeight : 0
        
        notificationImageView.snp.remakeConstraints {
            $0.height.equalTo(height)
            $0.leading.trailing.equalToSuperview()
            $0.top.equalTo(shopBackgroundView.snp.bottom).offset(10.adjusted)
            $0.bottom.equalToSuperview()
        }
    }
```

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 공지가 있을 때 | ![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-02-07 at 02 58 19](https://github.com/team-yello/YELLO-iOS/assets/68178395/5ab7ca2f-3097-451a-a8a9-52beb43ee6b6)|
| 공지가 없는 경우 | <Img src = "https://github.com/team-yello/YELLO-iOS/assets/68178395/27cd5e53-0d5d-494d-9f83-52b6e21dc769" width = 375 />


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #319 


