### PR TITLE
Fix  [#350] 구독 정보 오류 해결

### DIFF
--- a/YELLO-iOS/YELLO-iOS/Presentation/Payment/ViewController/PaymentPlusViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Payment/ViewController/PaymentPlusViewController.swift
@@ -457,7 +457,7 @@ extension PaymentPlusViewController {
     
     @objc private func paymentYelloPlusButtonTapped() {
         showLoadingIndicator()
-        if self.subscribeStatus == "NORMAL" {
+        if self.subscribeStatus == "normal" {
             print("구독하고 있지 않는 사용자입니다.")
             // 첫 구매 일자 구하기
             let currentDate = Date()


### PR DESCRIPTION
## ⛏ 작업 내용
구독 상태가 아닐 때 "이미 구독 중인 상품" 알럿이 뜨는 오류를 해결했습니다. 

## 📌 PR Point!
구독 상태가 소문자로 옴에 따라 `NORMAL`-> `normal`로 변경했습니다. 


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 화면종류 | 없습니다 |


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #350 
