### PR TITLE
Fix [#352] 출시 이후 발견한 오류 해결

### DIFF
--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/HighSchoolViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/HighSchoolViewController.swift
@@ -129,6 +129,7 @@ class HighSchoolViewController: OnboardingBaseViewController {
         isSelectLevel = true
         guard let buttonTitleLabel = sender.titleLabel else { return }
         self.schoolLevel = extractNumbers(from: buttonTitleLabel.text ?? "")
+        checkButtonEnable()
     }
     
     @objc func textfieldButtonTapped(_ sender: UIButton) {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/Helper/YelloSelectButton.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/Views/Helper/YelloSelectButton.swift
@@ -83,16 +83,20 @@ extension YelloSelectButton {
             $0.image = IconImage
             
         }
+        
         buttonLabel.do {
             $0.text = buttonText
             $0.font = .uiSubtitle02
         }
+        
         stackView.do {
             $0.addArrangedSubviews(iconImageView, buttonLabel)
             $0.axis = .vertical
             $0.alignment = .center
             $0.spacing = 4
+            $0.isUserInteractionEnabled = false
         }
+        
         checkButton.do {
             $0.backgroundColor = .grayscales800
             $0.makeCornerRound(radius: 10)

--- a/YELLO-iOS/YELLO-iOS/Presentation/Payment/View/PaymentView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Payment/View/PaymentView.swift
@@ -13,6 +13,7 @@ import Then
 final class PaymentView: BaseView {
     
     var nowPage: Int = 0
+    private var bannerTimer: Timer?
     private var paymentImage = [ImageLiterals.Payment.imgPaymentFirst,
                                 ImageLiterals.Payment.imgPaymentSecond,
                                 ImageLiterals.Payment.imgPaymentThird,
@@ -105,11 +106,18 @@ extension PaymentView: UICollectionViewDelegateFlowLayout {
 
 extension PaymentView {
     /// 3초마다 실행되는 타이머
-    func bannerTimer() {
-        let _: Timer = Timer.scheduledTimer(withTimeInterval: 3, repeats: true) { (Timer) in
+    func startBannerTimer() {
+        stopBannerTimer()
+        
+        bannerTimer = Timer.scheduledTimer(withTimeInterval: 3, repeats: true, block: { timer in
             self.bannerMove()
-        }
+        })
     }
+    
+    func stopBannerTimer() {
+        bannerTimer?.invalidate()
+    }
+    
     // 배너 움직이는 매서드
     func bannerMove() {
         /// 현재페이지가 마지막 페이지일 경우

--- a/YELLO-iOS/YELLO-iOS/Presentation/Payment/ViewController/PaymentPlusViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Payment/ViewController/PaymentPlusViewController.swift
@@ -94,7 +94,7 @@ final class PaymentPlusViewController: BaseViewController {
         checkRewardPossible()
         tabBarController?.tabBar.isHidden = true
         setInitialUI()
-        paymentPlusView.paymentView.bannerTimer()
+        paymentPlusView.paymentView.startBannerTimer()
         purchaseSubscribeNeed()
     }
     

--- a/YELLO-iOS/YELLO-iOS/Presentation/Recommending/View/KakaoFriendView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Recommending/View/KakaoFriendView.swift
@@ -9,6 +9,8 @@ import UIKit
 
 import SnapKit
 import Then
+import KakaoSDKAuth
+import KakaoSDKUser
 import KakaoSDKTalk
 
 final class KakaoFriendView: UIView {
@@ -244,7 +246,8 @@ extension KakaoFriendView {
     }
     
     func kakaoFriends(completion: @escaping () -> Void) {
-        TalkApi.shared.friends(limit: 100) { [weak self] (friends, error) in
+        checkKakaoToken()
+        TalkApi.shared.friends(limit: 100) { (friends, error) in
             if let error = error {
                 print(error)
             } else {
@@ -259,6 +262,21 @@ extension KakaoFriendView {
             completion()
         }
     }
+    
+    func checkKakaoToken() {
+        if AuthApi.hasToken() {
+            UserApi.shared.accessTokenInfo { accesstokenInfo, error in
+                if let error = error {
+                   print(error)
+                } else {
+                    debugPrint("kakao accessToken 유효성 확인")
+                }
+            }
+        } else {
+            self.showToast(message: "카카오톡 친구 불러오기에 실패했습니다. 다시 로그인 해주세요.", at: 100.adjustedHeight)
+        }
+    }
+    
 }
 
 extension KakaoFriendView: HandleAddFriendButton {


### PR DESCRIPTION
## ⛏ 작업 내용
발견/해결한 오류는 다음과 같습니다. 
- `추천친구 > 카톡 친구들`에서 카카오톡 친구가 불러와지지 않는 오류 
- `상점뷰 `상단의 pageControl 오류 해결
- `온보딩` 학교 -> 반 -> 학년 선택 시 버튼 enable 되지 않는 오류 

## 📌 PR Point!
#### 카카오 토큰 문제
카카오톡 친구가 불러와지지 않는 오류는 다음과 같은 오류 메시지를 표시했습니다. 
```
[‼️][Api.swift 151:29] -> response: api error: ClientFailed(reason: KakaoSDKCommon.ClientFailureReason.TokenNotFound, errorMessage: Optional("authentication tokens not exist."))
```
[공식 문서](https://developers.kakao.com/docs/latest/ko/kakaologin/trouble-shooting#oidc)에 따르면 카카오 토큰이 존재하지 않아 발생하는 문제입니다. 이 경우에는 재로그인 시 정상 작동하기 때문에 다시 로그인을 진행해야합니다. 
문제 발생 원인은 사용자가 카카오의 리프레쉬 토큰이 만료되는 시점까지 접속한 기록이 없을 시 토큰이 아예 유효하지 않기 때문입니다. 이 문제를 방지하기 위해서 카카오톡 친구를 불러올 때, 카카오 accessToken의 유효성을 검사하고 토큰이 없을 경우 안내 토스트 메시지를 띄우도록 처리했습니다. 토큰 확인 로직은 [여기](https://developers.kakao.com/docs/latest/ko/kakaologin/ios#token-presence) 참고했습니다!
https://github.com/team-yello/YELLO-iOS/blob/fef933007bcb4e44f04e71190714ebc79b4385e8/YELLO-iOS/YELLO-iOS/Presentation/Recommending/View/KakaoFriendView.swift#L266-L278

#### 상점뷰 타이머 문제 해결
상점뷰에 "광고보고 포인트 받기" 하단에 광고 시청 후 한시간 카운트다운 타이머가 추가되면서, 쓰레드 문제가 발생한 것 같습니다.  
해결하기 위해 광고 알럿 뷰가 dismiss되고 bannerTimer가 다시 시작될 때, 이를 무효화했다가 다시 설정하는 로직을 추가했습니다. 관련해서는 [`invaildate()`](https://developer.apple.com/documentation/foundation/timer/1415405-invalidate) 함수 참고해주세요!
두가지 타이머를 명확하게 구분하기 위해 `bannerTimer` 변수를 사용했습니다. 
https://github.com/team-yello/YELLO-iOS/blob/fef933007bcb4e44f04e71190714ebc79b4385e8/YELLO-iOS/YELLO-iOS/Presentation/Payment/View/PaymentView.swift#L109-L119



## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 화면종류 | 없습니다 |


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #352 
