### PR TITLE
Feat [#355] 프로필 변경 확인 팝업 및 수정 사항 적용

### DIFF
--- a/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
+++ b/YELLO-iOS/YELLO-iOS.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		36CDA9142B8208C400AC248E /* RewardServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36CDA9132B8208C400AC248E /* RewardServices.swift */; };
 		36CDA9172B823CE900AC248E /* lottie_spinner_loading_profile.json in Resources */ = {isa = PBXBuildFile; fileRef = 36CDA9162B823CE900AC248E /* lottie_spinner_loading_profile.json */; };
 		36CFF9A82B67F5FB008DDB9D /* EditProfileHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36CFF9A72B67F5FB008DDB9D /* EditProfileHeaderView.swift */; };
+		36D7D0502B949699008DB7A2 /* EditCheckView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D7D04F2B949699008DB7A2 /* EditCheckView.swift */; };
 		36D98F352B5FB2B7003B2B11 /* MainProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D98F342B5FB2B7003B2B11 /* MainProfileView.swift */; };
 		36D98F372B602442003B2B11 /* InfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D98F362B602442003B2B11 /* InfoView.swift */; };
 		36D98F392B617B5D003B2B11 /* EditProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D98F382B617B5D003B2B11 /* EditProfileViewController.swift */; };
@@ -555,6 +556,7 @@
 		36CDA9132B8208C400AC248E /* RewardServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardServices.swift; sourceTree = "<group>"; };
 		36CDA9162B823CE900AC248E /* lottie_spinner_loading_profile.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = lottie_spinner_loading_profile.json; sourceTree = "<group>"; };
 		36CFF9A72B67F5FB008DDB9D /* EditProfileHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileHeaderView.swift; sourceTree = "<group>"; };
+		36D7D04F2B949699008DB7A2 /* EditCheckView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCheckView.swift; sourceTree = "<group>"; };
 		36D98F342B5FB2B7003B2B11 /* MainProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainProfileView.swift; sourceTree = "<group>"; };
 		36D98F362B602442003B2B11 /* InfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoView.swift; sourceTree = "<group>"; };
 		36D98F382B617B5D003B2B11 /* EditProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileViewController.swift; sourceTree = "<group>"; };
@@ -1623,6 +1625,7 @@
 				36D98F3A2B617BBD003B2B11 /* EditProfileView.swift */,
 				36CFF9A72B67F5FB008DDB9D /* EditProfileHeaderView.swift */,
 				36ECE0E92B68B4EC000FCCBF /* EditSchoolInfoView.swift */,
+				36D7D04F2B949699008DB7A2 /* EditCheckView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -2940,6 +2943,7 @@
 				3662A0FC2A65795200F482EF /* IdValidResponseDTO.swift in Sources */,
 				C3A799992A49490A00D3EFD8 /* SceneDelegate.swift in Sources */,
 				2A3705A82A62DC90001AAC93 /* BaseResponse.swift in Sources */,
+				36D7D0502B949699008DB7A2 /* EditCheckView.swift in Sources */,
 				C31315A62A7A5E9400FB8B43 /* FriendSearchViewController.swift in Sources */,
 				C3FF24932A5E903C00A97D40 /* MyYelloDefaultTableViewCell.swift in Sources */,
 				36E427952A5CA59F0050B34E /* OnboardingEndViewController.swift in Sources */,

--- a/YELLO-iOS/YELLO-iOS/Global/Literals/String.swift
+++ b/YELLO-iOS/YELLO-iOS/Global/Literals/String.swift
@@ -318,7 +318,7 @@ enum StringLiterals {
             
             static let votingPointTitle = "투표하고 포인트 얻기"
             static let votingPoint = "최대 400p"
-            static let adPointTitle = "광고 보고 포인트 얻기"
+            static let adPointTitle = "광고 보고 무료 포인트 얻기"
             static let adPointsubTitle = "1시간에 한 번"
             static let adPoint = "10p"
             static let adPointErrorToast = "1시간에 한 번 재생할 수 있어요."

--- a/YELLO-iOS/YELLO-iOS/Global/Literals/String.swift
+++ b/YELLO-iOS/YELLO-iOS/Global/Literals/String.swift
@@ -317,7 +317,7 @@ enum StringLiterals {
             static let paymentAlertKeyDescription = "열람권으로 누가 쪽지를 보냈는지 알아보세요."
             
             static let votingPointTitle = "투표하고 포인트 얻기"
-            static let votingPoint = "최대 200p"
+            static let votingPoint = "최대 400p"
             static let adPointTitle = "광고 보고 포인트 얻기"
             static let adPointsubTitle = "1시간에 한 번"
             static let adPoint = "10p"
@@ -383,6 +383,10 @@ enum StringLiterals {
             static let saveButton = "저장"
             static let convertHighButton = "중/고등학생으로 전환"
             static let convertUnivButton = "대학생으로 전환"
+            
+            static let editCheckTitle = "올해 안에 한 번만 수정할 수 있어요.\n정말 변경하실 건가요?"
+            static let noButton = "아니요"
+            static let yesButton = "변경할게요"
         }
         
         enum Setting {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/UserInfoViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/UserInfoViewController.swift
@@ -51,8 +51,8 @@ class UserInfoViewController: OnboardingBaseViewController {
     // MARK: Custom Function
     func setDelegate() {
         NotificationCenter.default.addObserver(self,
-                                                       selector: #selector(textDidChange(_:)),
-                                                       name: UITextField.textDidChangeNotification,
+                                               selector: #selector(textDidChange(_:)),
+                                               name: UITextField.textDidChangeNotification,
                                                object: baseView.idTextField.textField)
         baseView.idTextField.textField.delegate = self
     }
@@ -106,32 +106,40 @@ class UserInfoViewController: OnboardingBaseViewController {
         UserManager.shared.yelloId = id
     }
     
-    // MARK: objc Function
-    @objc private func textDidChange(_ notification: Notification) {
-        guard let idText = baseView.idTextField.textField.text else { return }
-            self.checkDuplicate(id: idText)
-        self.checkButtonEnable()
-            if let textField = notification.object as? UITextField {
-                if let text = textField.text {
-                    
-                    if text.count > maxLength {
-                        textField.resignFirstResponder()
-                    }
-                    
-                    // 초과되는 텍스트 제거
-                    if text.count >= maxLength {
-                        let index = text.index(text.startIndex, offsetBy: maxLength)
-                        let newString = text[text.startIndex..<index]
-                        textField.text = String(newString)
-                    }
-                }
-            }
-        }
-    
-    @objc func idCancelTapped() {
+    private func setInitialStyle() {
         baseView.idTextField.helperLabel.setLabelStyle(text: StringLiterals.Onboarding.Id.idHelper, State: .id)
         baseView.idTextField.textField.setButtonState(state: .id)
         nextButton.setButtonEnable(state: false)
+    }
+    
+    // MARK: objc Function
+    @objc private func textDidChange(_ notification: Notification) {
+        guard let idText = baseView.idTextField.textField.text else { return }
+        if idText.isEmpty {
+            setInitialStyle()
+            return
+        }
+        self.checkDuplicate(id: idText)
+        self.checkButtonEnable()
+        if let textField = notification.object as? UITextField {
+            if let text = textField.text {
+                
+                if text.count > maxLength {
+                    textField.resignFirstResponder()
+                }
+                
+                // 초과되는 텍스트 제거
+                if text.count >= maxLength {
+                    let index = text.index(text.startIndex, offsetBy: maxLength)
+                    let newString = text[text.startIndex..<index]
+                    textField.text = String(newString)
+                }
+            }
+        }
+    }
+    
+    @objc func idCancelTapped() {
+        setInitialStyle()
     }
     
 }
@@ -142,19 +150,19 @@ extension UserInfoViewController: UITextFieldDelegate {
     func textFieldDidBeginEditing(_ textField: UITextField) {
         baseView.idTextField.textField.setButtonState(state: .cancel)
         baseView.idTextField.helperLabel.setLabelStyle(text: StringLiterals.Onboarding.Id.idHelper, State: .normal)
-    
+        
     }
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-            guard let text = textField.text else {return false}
-            
-            // 최대 글자수 이상을 입력한 이후에는 중간에 다른 글자를 추가할 수 없게끔 작동
-            if text.count >= maxLength && range.length == 0 && range.location < maxLength {
-                return false
-            }
-            
-            return true
+        guard let text = textField.text else {return false}
+        
+        // 최대 글자수 이상을 입력한 이후에는 중간에 다른 글자를 추가할 수 없게끔 작동
+        if text.count >= maxLength && range.length == 0 && range.location < maxLength {
+            return false
         }
+        
+        return true
+    }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.endEditing(true)
@@ -164,6 +172,10 @@ extension UserInfoViewController: UITextFieldDelegate {
     func textFieldDidEndEditing(_ textField: UITextField) {
         if textField == baseView.idTextField.textField {
             guard let idText = textField.text else { return }
+            if idText.isEmpty {
+                setInitialStyle()
+                return
+            }
             self.checkDuplicate(id: idText)
         }
         self.checkButtonEnable()

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Edit/View/EditCheckView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Edit/View/EditCheckView.swift
@@ -36,7 +36,7 @@ final class EditCheckView: UIView {
     private func setStyle() {
         self.backgroundColor = .black.withAlphaComponent(0.5)
         
-        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(noButtonClicked))
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(noButtonTapped))
         self.addGestureRecognizer(tapGestureRecognizer)
         
         contentsView.do {
@@ -58,7 +58,7 @@ final class EditCheckView: UIView {
             $0.setTitle(StringLiterals.Profile.EditProfile.noButton, for: .normal)
             $0.setTitleColor(.grayscales600, for: .normal)
             $0.titleLabel?.font = .uiButton
-            $0.addTarget(self, action: #selector(noButtonClicked), for: .touchUpInside)
+            $0.addTarget(self, action: #selector(noButtonTapped), for: .touchUpInside)
         }
         
         yesButton.do {
@@ -102,7 +102,7 @@ final class EditCheckView: UIView {
     }
     
     // MARK: Objc Function
-    @objc func noButtonClicked() {
+    @objc func noButtonTapped() {
         self.isHidden = true
         self.removeFromSuperview()
     }

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Edit/View/EditCheckView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Edit/View/EditCheckView.swift
@@ -27,7 +27,8 @@ final class EditCheckView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    private func setUI(){
+    
+    private func setUI() {
         setStyle()
         setLayout()
     }
@@ -41,6 +42,10 @@ final class EditCheckView: UIView {
         contentsView.do {
             $0.makeCornerRound(radius: 12.adjustedHeight)
             $0.backgroundColor = .grayscales900
+            $0.makeShadow(radius: 12,
+                          color: .black,
+                          offset: CGSize(width: 0, height: 0),
+                          opacity: 0.55)
         }
         
         titleLabel.do {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Edit/View/EditCheckView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Edit/View/EditCheckView.swift
@@ -1,0 +1,8 @@
+//
+//  EditCheckView.swift
+//  YELLO-iOS
+//
+//  Created by 지희의 MAC on 3/3/24.
+//
+
+import Foundation

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Edit/View/EditCheckView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Edit/View/EditCheckView.swift
@@ -5,4 +5,100 @@
 //  Created by 지희의 MAC on 3/3/24.
 //
 
-import Foundation
+import UIKit
+
+import SnapKit
+import Then
+
+final class EditCheckView: UIView {
+    // MARK: - Variables
+    // MARK: Property
+    let contentsView = UIView()
+    
+    private let titleLabel = UILabel()
+    let noButton = UIButton()
+    let yesButton = UIButton()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    private func setUI(){
+        setStyle()
+        setLayout()
+    }
+    
+    private func setStyle() {
+        self.backgroundColor = .black.withAlphaComponent(0.5)
+        
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(noButtonClicked))
+        self.addGestureRecognizer(tapGestureRecognizer)
+        
+        contentsView.do {
+            $0.makeCornerRound(radius: 12.adjustedHeight)
+            $0.backgroundColor = .grayscales900
+        }
+        
+        titleLabel.do {
+            $0.setTextWithLineHeight(text: StringLiterals.Profile.EditProfile.editCheckTitle, lineHeight: 22.adjustedHeight)
+            $0.font = .uiBody01
+            $0.textColor = .white
+        }
+        
+        noButton.do {
+            $0.setTitle(StringLiterals.Profile.EditProfile.noButton, for: .normal)
+            $0.setTitleColor(.grayscales600, for: .normal)
+            $0.titleLabel?.font = .uiButton
+            $0.addTarget(self, action: #selector(noButtonClicked), for: .touchUpInside)
+        }
+        
+        yesButton.do {
+            $0.setTitle(StringLiterals.Profile.EditProfile.yesButton, for: .normal)
+            $0.setTitleColor(.yelloMain500, for: .normal)
+            $0.titleLabel?.font = .uiButton
+        }
+    }
+    
+    private func setLayout() {
+        self.addSubview(contentsView)
+        
+        contentsView.addSubviews(titleLabel,
+                                 noButton,
+                                 yesButton)
+        
+        contentsView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.width.equalTo(280.adjustedWidth)
+            $0.height.equalTo(140.adjustedHeight)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(31.adjustedHeight)
+            $0.centerX.equalToSuperview()
+        }
+        
+        noButton.snp.makeConstraints {
+            $0.bottom.equalToSuperview().inset(23.adjustedHeight)
+            $0.leading.equalToSuperview().inset(27.adjustedWidth)
+            $0.width.equalTo(106.adjustedWidth)
+            $0.height.equalTo(28.adjustedHeight)
+        }
+        
+        yesButton.snp.makeConstraints {
+            $0.bottom.equalTo(noButton)
+            $0.trailing.equalToSuperview().inset(27.adjustedWidth)
+            $0.width.equalTo(106.adjustedWidth)
+            $0.height.equalTo(28.adjustedHeight)
+        }
+    }
+    
+    // MARK: Objc Function
+    @objc func noButtonClicked() {
+        self.isHidden = true
+        self.removeFromSuperview()
+    }
+}

--- a/YELLO-iOS/YELLO-iOS/Presentation/Profile/Edit/ViewController/EditSchoolInfoViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Profile/Edit/ViewController/EditSchoolInfoViewController.swift
@@ -28,11 +28,12 @@ final class EditSchoolInfoViewController: BaseViewController {
     var createDate: String = ""
     
     // MARK: Component
-    let editSchoolInfoView = EditSchoolInfoView()
-    let studentIdViewController = StudentIdViewController()
-    let schoolSearchViewController = FindSchoolViewController()
-    let majorSearchViewController = FindMajorViewController()
-    lazy var studentIdView = StudentIdView()
+    private let editSchoolInfoView = EditSchoolInfoView()
+    private let studentIdViewController = StudentIdViewController()
+    private let schoolSearchViewController = FindSchoolViewController()
+    private let majorSearchViewController = FindMajorViewController()
+    private lazy var studentIdView = StudentIdView()
+    private let editCheckView = EditCheckView()
     
     // MARK: - Function
     // MARK: LifeCycle
@@ -55,6 +56,16 @@ final class EditSchoolInfoViewController: BaseViewController {
     // MARK: Custom Function
     private func addTarget() {
         editSchoolInfoView.convertButton.addTarget(self, action: #selector(convertButtonTapped), for: .touchUpInside)
+        editCheckView.yesButton.addTarget(self, action: #selector(checkButtonTapped), for: .touchUpInside)
+    }
+    
+    override func setLayout() {
+        view.addSubview(editCheckView)
+        editCheckView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        editCheckView.isHidden = true
     }
     
     private func setDelegate() {
@@ -149,8 +160,12 @@ final class EditSchoolInfoViewController: BaseViewController {
         
         editSchoolInfoView.groupType = userGroupType
         
-        print("유저 타입 변경 완료 \n - 그룹 타입: \(userGroupType) \n - 그룹명: \(groupName) \n - 서브그룹명: \(subgroupName)")
         editSchoolInfoView.editTableView.reloadData()
+    }
+    
+    @objc func checkButtonTapped() {
+        updateProfile()
+        navigationController?.popViewController(animated: true)
     }
 }
 
@@ -300,8 +315,7 @@ extension EditSchoolInfoViewController: HandleSaveButtonDelegate {
             self.view.showToast(message: StringLiterals.Profile.EditProfile.notYetErrorMessage, at: 82.adjustedHeight)
         } else {
             if isEditAvailable && !isMajorSearchError {
-                updateProfile()
-                navigationController?.popViewController(animated: true)
+                editCheckView.isHidden = false
             } else if !isEditAvailable {
                 // 1년이내 변경한 경우
                 self.view.showToast(message: StringLiterals.Profile.EditProfile.editDateErrorMessage, at: 82.adjustedHeight)


### PR DESCRIPTION
## ⛏ 작업 내용
- 프로필 변경 시 확인하는 팝업을 추가했습니다. 
- 논의된 변경 사항을 적용했습니댜.


## 📌 PR Point!
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 온보딩 아이디 중복 확인에서 빈 문자를 보냈을 때 true 값이 들어옵니다. 이로 인해 "이미 존재하는 아이디입니다." 라이팅이 적용된 것을 확인했습니다. 수정을 위해 초기 상태로 만드는 함수 `setInitialState()`를 만들어서 중복성 검사 전 빈 문자열인 경우 초기 상태를 유지하도록 구현했습니다. 

```swift
private func setInitialStyle() {
        baseView.idTextField.helperLabel.setLabelStyle(text: StringLiterals.Onboarding.Id.idHelper, State: .id)
        baseView.idTextField.textField.setButtonState(state: .id)
        nextButton.setButtonEnable(state: false)
    }

func textFieldDidEndEditing(_ textField: UITextField) {
        if textField == baseView.idTextField.textField {
            guard let idText = textField.text else { return }
            if idText.isEmpty {
                setInitialStyle()
                return
            }
            self.checkDuplicate(id: idText)
        }
        self.checkButtonEnable()
    }
```


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 프로필 변경 팝업  | <img src="https://github.com/team-yello/YELLO-iOS/assets/68178395/7e579c55-fb45-4076-8577-572b35c338ea" width="350"/> |
| 아이디 빈 칸일 때 라이팅 적용 | ![RPReplay_Final1709467818](https://github.com/team-yello/YELLO-iOS/assets/68178395/617fc5ef-dc58-46c3-84ca-b5150604d634) |
| 상점 라이팅 변경 적용 | <img src="https://github.com/team-yello/YELLO-iOS/assets/68178395/bcbca544-52d1-415a-b5f2-8e75bc050613" width="350"/> |

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #355 
