### PR TITLE
Feat/#369/shop

### DIFF
--- a/YELLO-iOS/YELLO-iOS/Global/Literals/String.swift
+++ b/YELLO-iOS/YELLO-iOS/Global/Literals/String.swift
@@ -300,14 +300,14 @@ enum StringLiterals {
             
             static let sale = "SALE!"
             static let nameKeyOne = "이름 열람권\n1개"
-            static let nameKeyOnePrice = "1400원"
-            static let nameKeyOneSalePrice = "990원"
+            static let nameKeyOnePrice = " "
+            static let nameKeyOneSalePrice = "1400원"
             static let nameKeyTwo = "이름 열람권\n2개"
-            static let nameKeyTwoPrice = "2800원"
+            static let nameKeyTwoPrice = "개당 950원"
             static let nameKeyTwoSalePrice = "1900원"
             static let nameKeyFive = "이름 열람권\n5개"
             static let discount = "할인!"
-            static let nameKeyFivePriceBefore = "7000원"
+            static let nameKeyFivePriceBefore = "개당 780원"
             static let nameKeyFivePrice = "3900원"
             
             static let paymentAlertPlusTitle = "구독권을 얻었어요!"

--- a/YELLO-iOS/YELLO-iOS/Presentation/Payment/Button/PaymentNameKeyButton.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Payment/Button/PaymentNameKeyButton.swift
@@ -28,7 +28,6 @@ final class PaymentNameKeyButton: UIButton {
     
     let discountLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 35.adjustedWidth, height: 21.adjustedHeight))
     let priceBeforeLabel = UILabel()
-    let priceBeforeView = UIView()
     
     // MARK: - Function
     // MARK: LifeCycle
@@ -42,9 +41,10 @@ final class PaymentNameKeyButton: UIButton {
         setUI()
     }
     
-    init(state: KeyCount) {
+    init(state: KeyCount, isNonSale: Bool = false) {
         super.init(frame: CGRect())
         setUI()
+        self.discountLabel.isHidden = isNonSale
         setButtonState(state: state)
     }
     
@@ -60,7 +60,11 @@ final class PaymentNameKeyButton: UIButton {
         infoContainerView.do {
             $0.isUserInteractionEnabled = false
             $0.makeBorder(width: 1, color: .purpleSub700)
-            $0.makeCornerRound(radius: 10.adjustedHeight)
+            $0.makeCornerRound(radius: 10.adjusted)
+        }
+        
+        keyImageView.do {
+            $0.contentMode = .scaleAspectFit
         }
         
         nameKeyTitleLabel.do {
@@ -68,12 +72,13 @@ final class PaymentNameKeyButton: UIButton {
             $0.textColor = .purpleSub100
             $0.numberOfLines = 2
             $0.textAlignment = .center
-            $0.setTextWithLineHeight(text: StringLiterals.MyYello.Payment.nameKeyOne, lineHeight: 20.adjustedHeight)
+            $0.setTextWithLineHeight(text: StringLiterals.MyYello.Payment.nameKeyOne,
+                                     lineHeight: 20.adjustedHeight)
             $0.isUserInteractionEnabled = false
         }
         
         priceView.do {
-            $0.makeCornerRound(radius: 15.adjustedHeight)
+            $0.makeCornerRound(radius: 15.adjusted)
             $0.applyGradientBackground(topColor: UIColor(hex: "D96AFF"), bottomColor: UIColor(hex: "7C57FF"), startPointY: 0.5, endPointY: 0.5)
             $0.isUserInteractionEnabled = false
         }
@@ -97,11 +102,7 @@ final class PaymentNameKeyButton: UIButton {
         priceBeforeLabel.do {
             $0.font = .uiLabelSmall
             $0.textColor = .grayscales400
-            $0.isUserInteractionEnabled = false
-        }
-        
-        priceBeforeView.do {
-            $0.backgroundColor = .grayscales400
+            $0.setTextWithLineHeight(text: StringLiterals.MyYello.Payment.nameKeyFivePriceBefore, lineHeight: 14.adjusted)
             $0.isUserInteractionEnabled = false
         }
     }
@@ -109,18 +110,19 @@ final class PaymentNameKeyButton: UIButton {
     private func setLayout() {
         self.addSubviews(infoContainerView,
                          keyImageView)
-        
-        infoContainerView.addSubviews(nameKeyTitleLabel,priceView,discountLabel,priceBeforeLabel)
+        infoContainerView.addSubviews(nameKeyTitleLabel,
+                                      priceView,
+                                      discountLabel,
+                                      priceBeforeLabel)
         priceView.addSubview(priceLabel)
-        priceBeforeLabel.addSubviews(priceBeforeView)
         
         self.snp.makeConstraints {
-            $0.height.equalTo(172.adjustedHeight)
-            $0.width.equalTo(108.adjustedWidth)
+            $0.height.equalTo(172.adjusted)
+            $0.width.equalTo(108.adjusted)
         }
         
         infoContainerView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(10)
+            $0.top.equalToSuperview().offset(10.adjusted)
             $0.leading.trailing.bottom.equalToSuperview()
         }
         
@@ -131,14 +133,15 @@ final class PaymentNameKeyButton: UIButton {
         
         nameKeyTitleLabel.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.top.equalTo(keyImageView.snp.bottom).offset(10.adjustedHeight)
+            $0.top.equalTo(keyImageView.snp.bottom).offset(10.adjusted)
         }
         
         priceView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.top.equalTo(priceBeforeLabel.snp.bottom).offset(24.adjustedHeight)
-            $0.height.equalTo(30.adjustedHeight)
-            $0.width.equalTo(78.adjustedWidth)
+            $0.top.equalTo(priceBeforeLabel.snp.bottom).offset(24.adjusted)
+            $0.bottom.equalToSuperview().inset(12.adjusted)
+            $0.height.equalTo(30.adjusted)
+            $0.width.equalTo(78.adjusted)
         }
         
         priceLabel.snp.makeConstraints {
@@ -148,19 +151,13 @@ final class PaymentNameKeyButton: UIButton {
         discountLabel.snp.makeConstraints {
             $0.top.equalTo(priceView.snp.top).offset(-16.adjusted)
             $0.leading.equalToSuperview().offset(7.adjusted)
-            $0.height.equalTo(21.adjustedHeight)
-            $0.width.equalTo(35.adjustedWidth)
+            $0.height.equalTo(21.adjusted)
+            $0.width.equalTo(35.adjusted)
         }
         
         priceBeforeLabel.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.top.equalTo(nameKeyTitleLabel.snp.bottom)
-        }
-        
-        priceBeforeView.snp.makeConstraints {
-            $0.center.equalToSuperview()
-            $0.height.equalTo(1)
-            $0.width.equalToSuperview()
         }
     }
     

--- a/YELLO-iOS/YELLO-iOS/Presentation/Payment/View/PaymentPlusView.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Payment/View/PaymentPlusView.swift
@@ -26,7 +26,8 @@ final class PaymentPlusView: BaseView {
     let nameKeyLabel = UILabel()
     let nameKeyButtonStackView = UIStackView()
     
-    lazy var nameKeyOneButton = PaymentNameKeyButton(state: .one)
+    lazy var nameKeyOneButton = PaymentNameKeyButton(state: .one,
+                                                     isNonSale: true)
     lazy var nameKeyTwoButton = PaymentNameKeyButton(state: .two)
     lazy var nameKeyFiveButton = PaymentNameKeyButton(state: .five)
     
@@ -63,7 +64,7 @@ final class PaymentPlusView: BaseView {
         
         subscribeView.do {
             $0.backgroundColor = .grayscales900
-            $0.makeCornerRound(radius: 15.adjustedHeight)
+            $0.makeCornerRound(radius: 15.adjusted)
         }
         
         subscribeLabel.do {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Payment/ViewController/PaymentPlusViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Payment/ViewController/PaymentPlusViewController.swift
@@ -223,8 +223,8 @@ extension PaymentPlusViewController {
             Amplitude.instance().logEvent("complete_shop_buy", withEventProperties: ["buy_type": "subscribe", "buy_price": 2900])
             identify.add("user_revenue", value: NSNumber(value: 2900))
         case MyProducts.nameKeyOneProductID:
-            Amplitude.instance().logEvent("complete_shop_buy", withEventProperties: ["buy_type": "ticket1", "buy_price": 990])
-            identify.add("user_revenue", value: NSNumber(value: 990))
+            Amplitude.instance().logEvent("complete_shop_buy", withEventProperties: ["buy_type": "ticket1", "buy_price": 1400])
+            identify.add("user_revenue", value: NSNumber(value: 1400))
         case MyProducts.nameKeyTwoProductID:
             Amplitude.instance().logEvent("complete_shop_buy", withEventProperties: ["buy_type": "ticket2", "buy_price": 1900])
             identify.add("user_revenue", value: NSNumber(value: 1900))


### PR DESCRIPTION
## ⛏ 작업 내용
- 열람권 1개의 가격이 변경됨에 따라 UI 변경을 진행했습니다. 


## 📌 PR Point!
- `adjustedHeight`을 이용했을 경우 iPhone 15 Pro에서 의도치 않게 버튼 길이가 너무 길게 만들어지는 현상을 발견하여 `.adjusted`로 수정했습니다. 때문에 열쇠 이미지의 크기가 변화되는데 디자인과 논의 완료했습니다!
- `isNonSale`이라는 트리거를 추가하여 할인 라벨의 유무를 결정할 수 있도록 수정했습니다. 

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 상점뷰 (SE) | <img src = "https://github.com/team-yello/YELLO-iOS/assets/68178395/cbe125fc-8372-461d-a115-b9711af59a32" width = "375" > |
| 상점뷰 (15Pro) | <img src = "https://github.com/team-yello/YELLO-iOS/assets/68178395/957f2958-6321-4db9-b789-1700f36bc069"  width = "375" >  |


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #369 
