### PR TITLE
Fix [#371] 회원가입 오류 대응

### DIFF
--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoLoginViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/KakaoLoginViewController.swift
@@ -16,7 +16,9 @@ class KakaoLoginViewController: UIViewController {
     // MARK: Component
     let baseView = KakaoLoginView()
     let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as! SceneDelegate
-    
+    var isLoginSucess = false
+    var isFromOnboarding = false
+   
     // MARK: - Function
     // MARK: LifeCycle
     override func loadView() {
@@ -43,26 +45,26 @@ class KakaoLoginViewController: UIViewController {
                         if let error = error {
                             print(error)
                         } else {
-                                print("me() success.")
-                                if let user = user {
-                                    UserManager.shared.social = "KAKAO"
-                                    if let uuidInt = user.id { UserManager.shared.uuid = String(uuidInt) }
-                                    if let kakaoUser = user.kakaoAccount {
-                                        if let email = kakaoUser.email { UserManager.shared.email = email }
-                                        if let name = kakaoUser.name {
-                                            UserManager.shared.name = name
-                                        } else {
-                                            UserManager.shared.isNeedModName = true
-                                        }
-                                        if let gender = kakaoUser.gender {
-                                            UserManager.shared.gender = gender.rawValue.uppercased()
-                                        }
-                                        if let profile = kakaoUser.profile?.profileImageUrl {
-                                            UserManager.shared.profileImage = profile.absoluteString
-                                        }
+                            print("me() success.")
+                            if let user = user {
+                                UserManager.shared.social = "KAKAO"
+                                if let uuidInt = user.id { UserManager.shared.uuid = String(uuidInt) }
+                                if let kakaoUser = user.kakaoAccount {
+                                    if let email = kakaoUser.email { UserManager.shared.email = email }
+                                    if let name = kakaoUser.name {
+                                        UserManager.shared.name = name
+                                    } else {
+                                        UserManager.shared.isNeedModName = true
+                                    }
+                                    if let gender = kakaoUser.gender {
+                                        UserManager.shared.gender = gender.rawValue.uppercased()
+                                    }
+                                    if let profile = kakaoUser.profile?.profileImageUrl {
+                                        UserManager.shared.profileImage = profile.absoluteString
                                     }
                                 }
                             }
+                        }
                         
                         UserApi.shared.scopes(scopes: ["friends"]) { (scopeInfo, error) in
                             if let error = error {
@@ -108,7 +110,7 @@ class KakaoLoginViewController: UIViewController {
                     UserManager.shared.isResigned = data.isResigned
                     Amplitude.instance().logEvent("complete_onboarding_finish")
                     
-                    if isFirstTime() {
+                    if isFirstTime() || self.isFromOnboarding {
                         let rootViewController = PushSettingViewController()
                         self.sceneDelegate  .window?.rootViewController = UINavigationController(rootViewController: rootViewController)
                     } else if UserManager.shared.isResigned {
@@ -141,6 +143,7 @@ class KakaoLoginViewController: UIViewController {
                 if let error = error {
                     print("🚩🚩\(error)")
                 } else {
+                    self.isLoginSucess = true
                     print("----🚩카카오 톡으로 로그인 성공🚩----")
                     DispatchQueue.main.async {
                         Amplitude.instance().logEvent("complete_onboarding_finish")
@@ -156,6 +159,7 @@ class KakaoLoginViewController: UIViewController {
                 if let error = error {
                     print(error)
                 } else {
+                    self.isLoginSucess = true
                     print("카카오 계정으로 로그인 성공")
                     Amplitude.instance().logEvent("complete_onboarding_finish")
                     guard let kakaoToken = oauthToken?.accessToken else { return }
@@ -164,6 +168,10 @@ class KakaoLoginViewController: UIViewController {
                 }
             }
         }
+        if !isLoginSucess {
+            self.baseView.kakaoButton.isEnabled = true
+        }
+        
     }
     
     @objc func privacyButtonDidTap() {

--- a/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/RecommendIdViewController.swift
+++ b/YELLO-iOS/YELLO-iOS/Presentation/Onboarding/ViewController/RecommendIdViewController.swift
@@ -21,6 +21,7 @@ class RecommendIdViewController: OnboardingBaseViewController {
     
     // MARK: Component
     let pushViewController = PushSettingViewController()
+    let kakaoLoginViewController = KakaoLoginViewController()
     let baseView = RecommendIdView()
     let text = ""
     
@@ -133,7 +134,6 @@ class RecommendIdViewController: OnboardingBaseViewController {
                     print("no data")
                     return
                 }
-                dump(data)
                 KeychainHandler.shared.accessToken = data.accessToken
                 UserDefaults.standard.setValue(true, forKey: "isLoggined")
                 setAcessToken(accessToken: data.accessToken)
@@ -169,15 +169,13 @@ class RecommendIdViewController: OnboardingBaseViewController {
                 Amplitude.instance().setUserProperties(userProperties)
                 self.didPostUserInfo = true
                 self.navigationController?.pushViewController(pushViewController, animated: false)
-            case .requestErr(let data):
-                self.isFail = true
-                self.view.showToast(message: "오류가 발생했습니다. 잠시후 다시 시도해주세요.")
-                Crashlytics.crashlytics().setUserID(UserManager.shared.yelloId)
-                Crashlytics.crashlytics().log("dto: \(requestDTO) \n message: \(data.message)")
-                return
             default:
                 self.isFail = true
                 self.view.showToast(message: "오류가 발생했습니다. 잠시후 다시 시도해주세요.")
+                let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as! SceneDelegate
+                kakaoLoginViewController.isFromOnboarding = true
+                sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: kakaoLoginViewController)
+                
                 return
             }
         }
@@ -221,8 +219,8 @@ class RecommendIdViewController: OnboardingBaseViewController {
         
         if isFail {
             self.view.showToast(message: "오류가 발생했습니다. 잠시후 다시 시도해주세요.")
-            return
         }
+        
         if sender == skipButton {
             UserManager.shared.recommendId = ""
             Amplitude.instance().logEvent("click_onboarding_recommend", withEventProperties: ["rec_exist": "pass"] )


### PR DESCRIPTION
## ⛏ 작업 내용
온보딩 오류 발생 시 카카오 로그인으로 이동하는 플로우를 추가했습니다. 


## 📌 PR Point!
- 기존에 로그인 버튼은 한 번 누르면 비활성화되어 취소 후 다시 돌아왔을 때 동작하지 않음을 확인했습니다. 이를 해결하기 위해 로그인이 되지 않았으면 버튼을 활성화하는 로직을 추가했습니다. 
- 회원가입 서버통신 실패로 로그인 화면으로 돌아온 경우, 삭제 후 다시 들어온 것과 마찬가지로 푸시 알림 설정과 튜토리얼으로 돌아가도록 구현했습니다. 

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 로그인 로직 | ![Simulator Screen Recording - iPhone 15 Pro - 2024-04-12 at 00 20 41](https://github.com/team-yello/YELLO-iOS/assets/68178395/fa834913-9386-4d31-8b7a-39dfb65c4732) |


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #371 
